### PR TITLE
Remove deprecated --unsafe-pruning flag

### DIFF
--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -142,7 +142,7 @@ PC_TELEMETRY="
 
 PC_PRUNING="
 {%- if node_parachain_pruning > 0 %}
---pruning={{ node_parachain_pruning }} --unsafe-pruning
+--pruning={{ node_parachain_pruning }}
 {%- else %}
 --pruning=archive
 {%- endif %}"


### PR DESCRIPTION
As it has been removed in latest binaries (eg.polkadot-parachain 0.9.320-bae8bd3403e).