### PR TITLE
Update subkey filter

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.4
+version: 1.0.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -37,7 +37,7 @@ Small wrapper around subkey inspect command.
 Subkey binary should be installed on host machine. 
 
 ```bash
-curl -fSL -o subkey 'https://s3.eu-central-1.amazonaws.com/releases.parity.io/substrate/x86_64-debian%3Astretch/v3.0.0/subkey/subkey'
+curl -fSL -o subkey 'https://releases.parity.io/substrate/x86_64-debian%3Astretch/v3.0.0/subkey/subkey'
 chmod +x subkey
 sudo mv subkey /usr/local/bin/subkey
 subkey -V

--- a/plugins/filter/subkey.py
+++ b/plugins/filter/subkey.py
@@ -7,31 +7,39 @@ import subprocess
 import json
 
 
-def subkey_inspect(a, network='', scheme='', public=False):
+def subkey_inspect(uri, network='', scheme='', public=False):
     """Run subkey inspect command and return output."""
-    a = to_text(a, errors='surrogate_or_strict', nonstring='simplerepr')
+    uri = to_text(uri, errors='surrogate_or_strict', nonstring='simplerepr')
 
     args = []
+    log_uri = '<URI>'
     if scheme:
         args.extend(['--scheme', scheme])
     if network:
         args.extend(['--network', network])
     if public:
         args.extend(['--public'])
+        log_uri = uri
 
     try:
-        process = subprocess.Popen(['subkey', 'inspect', a, "--output-type=json", *args],
+        process = subprocess.Popen(['subkey', 'inspect', uri, "--output-type=json", *args],
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE,
                                    universal_newlines=True)
+    except FileNotFoundError:
+        raise AnsibleFilterError(
+            "subkey binary is required for this filter. Please, install it on local machine: sudo curl -fSL -o "
+            "/usr/local/bin/subkey 'https://releases.parity.io/substrate/x86_64-debian%3Astretch/v3.0.0/subkey/subkey' "
+            "&& chmod +x /usr/local/bin/subkey"
+        )
     except Exception as e:
         raise AnsibleFilterError(
             'Error running subkey command. \nCommand: subkey inspect %s %s \nError: %s'
-            % (a, ' '.join(args), e))
+            % (log_uri, ' '.join(args), e))
     stdout, stderr = process.communicate()
     if process.returncode != 0:
         raise AnsibleFilterError('Error running subkey command. \nCommand: subkey inspect %s %s \nstdout: %s \nstderr: %s'
-                                 % (a, ' '.join(args), stdout, stderr))
+                                 % (log_uri, ' '.join(args), stdout, stderr))
     try:
         output = json.loads(stdout)
     except Exception as e:

--- a/roles/key_inject/tasks/inject.yml
+++ b/roles/key_inject/tasks/inject.yml
@@ -27,7 +27,7 @@
 
     - name: Inject | Check {{ item.type }} key results
       ansible.builtin.debug:
-        msg: "Key {{ key_inject_pub_key }} is {{ 'NOT ' if not key_inject_uri.json.result else '' }}present in keystore"
+        msg: "Key {{ key_inject_pub_key }} ({{ item.type }}, {{ tem.scheme | default('sr25519') }}) is {{ 'NOT ' if not key_inject_uri.json.result else '' }}present in keystore"
       changed_when: not key_inject_uri.json.result
 
     - name: Inject | Inject {{ item.type }} keys


### PR DESCRIPTION
If `subkey` is not present on the controller machine the error is very confusing: 
```
TASK [parity.chain.key_inject : Inject | Setting gran pub keys] **************************************************************
fatal: [host]: FAILED! => {"msg": "Error running subkey command. \nCommand: subkey inspect <URI> --scheme ed25519 \nError: [Errno 2] No such file or directory: 'subkey'"}
```

It is not clear that `subkey` should be installed in on controller machine not on the remote host.  This PR should improve the log output. 

closes: [#2078](https://github.com/paritytech/devops/issues/2078)