### PR TITLE
Set use_proxy=false when doing http request to local addresses

### DIFF
--- a/roles/key_inject/tasks/inject.yml
+++ b/roles/key_inject/tasks/inject.yml
@@ -7,7 +7,7 @@
 
     - name: Inject | Check {{ item.type }} key
       ansible.builtin.uri:
-        url: "http://localhost:{{ item.rpc_port | default(key_inject_relay_chain_rpc_port) }}"
+        url: "http://127.0.0.1:{{ item.rpc_port | default(key_inject_relay_chain_rpc_port) }}"
         method: POST
         body:
           jsonrpc: "2.0"
@@ -33,7 +33,7 @@
 
     - name: Inject | Inject {{ item.type }} keys
       ansible.builtin.uri:
-        url: "http://localhost:{{ item.rpc_port | default(key_inject_relay_chain_rpc_port) }}"
+        url: "http://127.0.0.1:{{ item.rpc_port | default(key_inject_relay_chain_rpc_port) }}"
         method: POST
         body:
           jsonrpc: "2.0"

--- a/roles/key_inject/tasks/inject.yml
+++ b/roles/key_inject/tasks/inject.yml
@@ -17,6 +17,7 @@
         body_format: json
         headers:
           Content-Type: 'application/json'
+        use_proxy: false
       changed_when: false
       check_mode: false
       # retries 10 times, because this role can run after node role without pause, and the node is not up yet
@@ -42,6 +43,7 @@
         body_format: json
         headers:
           Content-Type: 'application/json'
+        use_proxy: false
       changed_when: true
       notify: Restart service
       register: key_inject_uri

--- a/roles/node/molecule/default/verify.yml
+++ b/roles/node/molecule/default/verify.yml
@@ -23,6 +23,7 @@
       body_format: json
       headers:
         Content-Type: 'application/json'
+      use_proxy: false
     register: _system_health_result
 
   - name: Print system_syncState
@@ -56,6 +57,7 @@
       body_format: json
       headers:
         Content-Type: 'application/json'
+      use_proxy: false
     register: _system_health_result
 
   - name: Print system_health
@@ -75,6 +77,7 @@
       body_format: json
       headers:
         Content-Type: 'application/json'
+      use_proxy: false
     register: _system_syncstate_result
 
   - name: Print system_syncState

--- a/roles/node/molecule/parachain/verify.yml
+++ b/roles/node/molecule/parachain/verify.yml
@@ -30,6 +30,7 @@
       body_format: json
       headers:
         Content-Type: 'application/json'
+      use_proxy: false
     loop:
       - 9933
       - 9943
@@ -57,6 +58,7 @@
       body_format: json
       headers:
         Content-Type: 'application/json'
+      use_proxy: false
     loop:
       - 9933
       - 9943

--- a/roles/node/tasks/001-health-check.yml
+++ b/roles/node/tasks/001-health-check.yml
@@ -30,6 +30,7 @@
         method: "system_health"
         params: []
       return_content: yes
+      use_proxy: false
     register: _node_health_check_register
     until: _node_health_check_register.status is defined and _node_health_check_register.status == 200
     retries: 12
@@ -54,6 +55,7 @@
         method: "system_version"
         params: [ ]
       return_content: yes
+      use_proxy: false
     register: _node_version_check_register
     until: _node_version_check_register.status is defined and _node_version_check_register.status == 200
     retries: 2


### PR DESCRIPTION
This is required in one of our node deployments where the node can only reach the internet through an http proxy. In this case, the `HTTP_PROXY`/`HTTPS_PROXY` variable interferes with request to local addresses for healthcheck and key injection. This change fixes this issues while having no impact on users who don't set any HTTP env vars.