### PR TITLE
make google SDK installing optional

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.8
+version: 1.0.9
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -109,6 +109,8 @@ node_chain_backup_url: ""
 node_chain_backup_gcp_bucket: ""
 # Link to a gcp backup, you have to specify a full path including a bucket name.
 node_chain_backup_gcp_path: ""
+# If you don't have pre-installed google SDK the role can install it
+node_chain_backup_gcp_install_sdk: false
 # If it's true, backup will be restored using the diff mode even if the 'db' folder exists.
 # It works only for diff sync restoring types, there is only one now - gcp.
 # It can be useful if you want to restore a broken db very quickly.

--- a/roles/node/tasks/802-restore-chain-gcp.yml
+++ b/roles/node/tasks/802-restore-chain-gcp.yml
@@ -1,24 +1,28 @@
 ---
 
-- name: Restore {{ item.part }} | GCP restoring | Install packages
-  ansible.builtin.package:
-    name: gpg
-    update_cache: yes
+- block:
 
-- name: Restore {{ item.part }} | GCP restoring | Add Google cloud apt GPG key
-  ansible.builtin.apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+  - name: Restore {{ item.part }} | GCP restoring | Install packages
+    ansible.builtin.package:
+      name: gpg
+      update_cache: yes
 
-- name: Restore {{ item.part }} | GCP restoring | Add gce-sdk repository
-  ansible.builtin.apt_repository:
-    repo: deb http://packages.cloud.google.com/apt cloud-sdk-{{ ansible_distribution_release }} main
-    filename: /etc/apt/sources.list.d/gce_sdk.list
-    update_cache: yes
+  - name: Restore {{ item.part }} | GCP restoring | Add Google cloud apt GPG key
+    ansible.builtin.apt_key:
+      url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
 
-- name: Restore {{ item.part }} | GCP restoring | Install packages
-  ansible.builtin.package:
-    name: google-cloud-sdk
-    update_cache: no
+  - name: Restore {{ item.part }} | GCP restoring | Add gce-sdk repository
+    ansible.builtin.apt_repository:
+      repo: deb http://packages.cloud.google.com/apt cloud-sdk-{{ ansible_distribution_release }} main
+      filename: /etc/apt/sources.list.d/gce_sdk.list
+      update_cache: yes
+
+  - name: Restore {{ item.part }} | GCP restoring | Install packages
+    ansible.builtin.package:
+      name: google-cloud-sdk
+      update_cache: no
+
+  when: node_chain_backup_gcp_install_sdk | bool
 
 - name: Restore {{ item.part }} | GCP restoring | Check last version
   ansible.builtin.command: gsutil cat {{ item.gcp_path }}/latest_version.meta.txt


### PR DESCRIPTION
Users can install google SDK using another way or have a pre-installed one.

Signed-off-by: kogeler <roman.gavrilov@parity.io>