### PR TITLE
pruning CLI flag was changed

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.9
+version: 1.0.10
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -179,7 +179,7 @@ node_parachain_ws_max_connections: "100"
 
 ### Node preferences
 node_parachain_paritydb_enable: false
-node_parachain_db_cache: 512
+node_parachain_db_cache: ""
 # You can redefine any variables from playbooks directly
 # Values from the "_node_profiles" are used by default
 node_parachain_in_peers: "25"

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -84,7 +84,9 @@ node_ws_max_connections: "100"
 ### Node preferences
 node_paritydb_enable: false
 node_db_cache: ""
-# Set amount of blocks to save in the pruning mode, 0 - pruning mode is disabled
+# amount of blocks to save state in the pruning mode
+# if you need the state pruning mode the recommended (default) value is 256
+# 0 - the state pruning mode is disabled, keep the state of all blocks ('--state-pruning archive')
 node_pruning: 0
 # You can specify any custom options as a list
 node_custom_options: []
@@ -182,7 +184,9 @@ node_parachain_db_cache: 512
 # Values from the "_node_profiles" are used by default
 node_parachain_in_peers: "25"
 node_parachain_out_peers: "25"
-# Set amount of blocks to save in the pruning mode, 0 - pruning mode is disabled
+# amount of blocks to save state in the pruning mode
+# if you need the state pruning mode the recommended (default) value is 256
+# 0 - the state pruning mode is disabled, keep the state of all blocks ('--state-pruning archive')
 node_parachain_pruning: 0
 # You can specify any custom options as a list
 node_parachain_custom_options: []

--- a/roles/node/molecule/README.md
+++ b/roles/node/molecule/README.md
@@ -43,6 +43,7 @@ You can deploy role locally in docker container, e.g to check node logs.
 #### Relaychain
 ```bash
 cd roles/node
+molecule lint
 molecule converge
 molecule verify
 molecule login
@@ -53,14 +54,10 @@ molecule destroy # to clean everything
 #### Parachain
 ```bash
 cd roles/node
-molecule test  
-cd roles/node
+molecule lint
 molecule converge --scenario-name parachain
 molecule verify --scenario-name parachain
-molecule login --scenario-name parachain --host instance1 
-> journalctl -f
-> exit
-molecule login -s parachain -h instance2
+molecule login --scenario-name parachain --host instance-parachain 
 > journalctl -f
 > exit
 molecule destroy --scenario-name parachain # to clean everything

--- a/roles/node/molecule/default/group_vars/all.yml
+++ b/roles/node/molecule/default/group_vars/all.yml
@@ -3,7 +3,7 @@ ansible_user: root
 
 ## Node
 node_chain: polkadot
-node_binary_version: v0.9.30
+node_binary_version: v0.9.40
 node_binary: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot
 node_binary_signature: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot.asc
 node_chain_backup_restoring_type: "none"

--- a/roles/node/molecule/default/molecule.yml
+++ b/roles/node/molecule/default/molecule.yml
@@ -24,6 +24,8 @@ provisioner:
     D: True
 verifier:
   name: ansible
+  options:
+    D: True
 lint: |
   set -e
   yamllint .

--- a/roles/node/molecule/default/prepare.yml
+++ b/roles/node/molecule/default/prepare.yml
@@ -2,10 +2,12 @@
   hosts: all
   gather_facts: false
   pre_tasks:
+    - name: Install python
+      ansible.builtin.raw: apt -y update && apt install -y python3
+      changed_when: false
     - name: Install required packages
       ansible.builtin.apt:
         name:
-          - python3
           - gpg
-        update_cache: yes
+        update_cache: no
       changed_when: false

--- a/roles/node/molecule/parachain/group_vars/all.yml
+++ b/roles/node/molecule/parachain/group_vars/all.yml
@@ -2,7 +2,7 @@
 ansible_user: root
 
 # Common
-node_binary_version: v0.9.270
+node_binary_version: v0.9.380
 node_binary: https://github.com/paritytech/cumulus/releases/download/{{ node_binary_version }}/polkadot-parachain
 node_binary_signature: https://github.com/paritytech/cumulus/releases/download/{{ node_binary_version }}/polkadot-parachain.asc
 node_app_name: "shell"

--- a/roles/node/molecule/parachain/molecule.yml
+++ b/roles/node/molecule/parachain/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: ${DRIVER:-docker}
 platforms:
-  - name: instance
+  - name: instance-parachain
     # LXD
     source:
       alias: debian/bullseye/amd64
@@ -18,6 +18,10 @@ platforms:
     # to pull image  from docker hub uncomment this
     pre_build_image: true
 
+provisioner:
+  name: ansible
+  options:
+    D: True
 verifier:
   name: ansible
   options:

--- a/roles/node/molecule/parachain/prepare.yml
+++ b/roles/node/molecule/parachain/prepare.yml
@@ -2,10 +2,12 @@
   hosts: all
   gather_facts: false
   pre_tasks:
+    - name: Install Python
+      ansible.builtin.raw: apt -y update && apt install -y python3
+      changed_when: false
     - name: Install required packages
       ansible.builtin.apt:
         name:
-          - python3
           - gpg
-        update_cache: yes
+        update_cache: no
       changed_when: false

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -27,6 +27,7 @@
     mode: 0755
     owner: "root"
     group: "root"
+    timeout: 30
     headers:
       PRIVATE-TOKEN: "{{ node_binary_download_private_token }}"
   check_mode: false

--- a/roles/node/tasks/900-systemd.yml
+++ b/roles/node/tasks/900-systemd.yml
@@ -2,6 +2,7 @@
 
 - name: Systemd | Get public IP
   community.general.ipify_facts:
+    timeout: 30
   register: _node_ipify_result
   until: _node_ipify_result.failed is defined and not _node_ipify_result.failed
   retries: 3

--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -57,9 +57,9 @@ RC_TELEMETRY="
 
 RC_PRUNING="
 {%- if node_pruning > 0 %}
---pruning={{ node_pruning }}
+--state-pruning={{ node_pruning }}
 {%- else %}
---pruning=archive
+--state-pruning=archive
 {%- endif %}"
 
 RC_LOGS="
@@ -144,9 +144,9 @@ PC_TELEMETRY="
 
 PC_PRUNING="
 {%- if node_parachain_pruning > 0 %}
---pruning={{ node_parachain_pruning }}
+--state-pruning={{ node_parachain_pruning }}
 {%- else %}
---pruning=archive
+--state-pruning=archive
 {%- endif %}"
 
 PC_LOGS="

--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -129,9 +129,11 @@ PC_CONNECTIONS="--in-peers {{ node_parachain_in_peers }} --out-peers {{ node_par
 
 PC_DB="\
 {% if node_parachain_paritydb_enable %}
---database paritydb-experimental \
+--database paritydb \
 {% endif %}
---db-cache {{ node_parachain_db_cache }}"
+{% if node_parachain_db_cache != '' %}
+--db-cache {{ node_parachain_db_cache }}
+{% endif %}"
 
 PC_TELEMETRY="
 {%- if not node_parachain_telemetry_enable %}


### PR DESCRIPTION
Changes:
* the `--pruning` CLI flag [was renamed](https://github.com/paritytech/substrate/pull/11934)
  Also, we meet the `WARN main state-db: Large pruning window of 3700 detected! THIS CAN LEAD TO HIGH MEMORY USAGE AND CRASHES. Reduce the pruning window or switch your database to paritydb.` log warning. We should use a value like 256 for the state pruning mode. It's the default value according to the documentation
* the `paritydb` CLI flag was renamed. paritydb isn't an experimental feature anymore
  
* [the issues 22](https://github.com/paritytech/ansible-galaxy/issues/22) was fixed completely
* network timeouts were increased for the slow network case
* molecule scenarios were fixed