### PR TITLE
node: permissions are applied recursively for the root dir

### DIFF
--- a/roles/node/tasks/900-systemd.yml
+++ b/roles/node/tasks/900-systemd.yml
@@ -12,6 +12,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    recurse: yes
     mode: '0755'
     owner: "{{ node_user }}"
     group: "{{ node_user }}"


### PR DESCRIPTION
It fixes the issue when the id of the user is changed for some reasons.