### PR TITLE
remove recurse option when creating directories

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.10
+version: 1.0.11
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/tasks/900-systemd.yml
+++ b/roles/node/tasks/900-systemd.yml
@@ -12,7 +12,6 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    recurse: yes
     mode: '0755'
     owner: "{{ node_user }}"
     group: "{{ node_user }}"


### PR DESCRIPTION
This often results in the playbook failing when the directory already exists and contains files. When the binary is running, it will also remove files in that folder, causing the playbook to fail.