### PR TITLE
[node] Support legacy rpc options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   molecule:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - run: pip3 install ansible molecule[docker] yamllint ansible-lint
-      - run: molecule test
+      - run: pip3 install yamllint ansible ansible-lint molecule molecule-plugins[docker] docker
+      - run: molecule test --all
         working-directory: "${{ github.repository }}/roles/node"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.11
+version: 1.1.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -67,6 +67,10 @@ node_wasm_runtime: ""
 node_p2p_private_key: ""
 
 ### Ports and addresses
+# Substrate changed the default rpc flags: https://github.com/paritytech/substrate/pull/13384
+# Port `9933` was replaced by combined port `9944`
+# If your node is still using the old binary with old RPC flags, please set this to true
+node_legacy_rpc_flags: true
 ## p2p
 node_p2p_bind_addr: "0.0.0.0"
 node_p2p_port: "30333"
@@ -77,7 +81,7 @@ node_p2p_ws_port: "30334"
 node_prometheus_port: "9615"
 node_prometheus_external_enable: true
 ## api
-node_rpc_port: "9933"
+node_rpc_port: "{{ '9933' if node_legacy_rpc_flags else node_rpc_ws_port }}"
 node_rpc_ws_port: "9944"
 node_ws_max_connections: "100"
 
@@ -173,7 +177,7 @@ node_parachain_p2p_ws_port: "30344"
 node_parachain_prometheus_port: "9625"
 node_parachain_prometheus_external_enable: true
 ## api
-node_parachain_rpc_port: "9943"
+node_parachain_rpc_port: "{{ '9943' if node_legacy_rpc_flags else node_parachain_rpc_ws_port }}"
 node_parachain_rpc_ws_port: "9954"
 node_parachain_ws_max_connections: "100"
 

--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -17,7 +17,11 @@ RC_ROLE_SPECIFIC="\
 {% if node_role == 'validator' %}
 --validator
 {%- elif node_role == 'rpc' %}
+{% if node_legacy_rpc_flags %}
 --unsafe-ws-external \
+{% else %}
+--unsafe-rpc-external \
+{% endif %}
 --rpc-methods Safe \
 --rpc-cors '*'
 {%- elif node_role == 'boot' %}
@@ -74,8 +78,12 @@ RC_METRICS="\
 --prometheus-port {{ node_prometheus_port }}"
 
 RC_WS="\
+{% if node_legacy_rpc_flags %}
 --ws-port {{ node_rpc_ws_port }} \
---ws-max-connections {{ node_ws_max_connections }}"
+--ws-max-connections {{ node_ws_max_connections }}
+{% else %}
+--rpc-max-connections {{ node_ws_max_connections }}
+{%- endif %}"
 
 RC_RPC="--rpc-port {{ node_rpc_port }}"
 
@@ -108,7 +116,11 @@ PC_ROLE_SPECIFIC="\
 {%- elif node_parachain_role == 'validator' %}
 --validator
 {%- elif node_parachain_role == 'rpc' %}
+{% if node_legacy_rpc_flags %}
 --unsafe-ws-external \
+{% else %}
+--unsafe-rpc-external \
+{% endif %}
 --rpc-methods Safe \
 --rpc-cors '*'
 {%- elif node_parachain_role == 'full' %}
@@ -163,8 +175,12 @@ PC_METRICS="\
 --prometheus-port {{ node_parachain_prometheus_port }}"
 
 PC_WS="\
+{% if node_legacy_rpc_flags %}
 --ws-port {{ node_parachain_rpc_ws_port }} \
---ws-max-connections {{ node_parachain_ws_max_connections }}"
+--ws-max-connections {{ node_parachain_ws_max_connections }}
+{% else %}
+--rpc-max-connections {{ node_parachain_ws_max_connections }}
+{%- endif %}"
 
 PC_RPC="--rpc-port {{ node_parachain_rpc_port }}"
 

--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -81,7 +81,7 @@ RC_WS="\
 {% if node_legacy_rpc_flags %}
 --ws-port {{ node_rpc_ws_port }} \
 --ws-max-connections {{ node_ws_max_connections }}
-{% else %}
+{%- else %}
 --rpc-max-connections {{ node_ws_max_connections }}
 {%- endif %}"
 
@@ -178,7 +178,7 @@ PC_WS="\
 {% if node_legacy_rpc_flags %}
 --ws-port {{ node_parachain_rpc_ws_port }} \
 --ws-max-connections {{ node_parachain_ws_max_connections }}
-{% else %}
+{%- else %}
 --rpc-max-connections {{ node_parachain_ws_max_connections }}
 {%- endif %}"
 


### PR DESCRIPTION

In this PR https://github.com/paritytech/substrate/pull/13384 the legacy rpc options was removed. 
## Changes

1. add support for the  legacy rpc options 
