### PR TITLE
Add option to not immediately start the node

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.1
+version: 1.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -77,7 +77,7 @@ node_legacy_rpc_flags: true
 node_p2p_bind_addr: "0.0.0.0"
 node_p2p_port: "30333"
 node_p2p_public_port: "{{ node_p2p_port }}"
-# Disable discovering public IP of the node (i.e., behind NAT) and omit `--public-addr` flag
+# Enable discovering public IP of the node (i.e., behind NAT) and set `--public-addr` flag
 node_enable_public_ip_detection: true
 # It works only for the 'boot' mode!
 node_p2p_ws_port: "30334"

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -38,6 +38,8 @@ node_force_restart: false
 # to avoid this set the node_handler_id, it can be set only as play variable not as the host variable.
 # see https://github.com/ansible/ansible/issues/76855
 node_handler_id: ""
+# Start service after playbook execution is completed
+node_start_service: true
 
 ### File used for Ansible annotation
 # File name for prometheus node-exporter textfile collector
@@ -75,6 +77,8 @@ node_legacy_rpc_flags: true
 node_p2p_bind_addr: "0.0.0.0"
 node_p2p_port: "30333"
 node_p2p_public_port: "{{ node_p2p_port }}"
+# Disable discovering public IP of the node (i.e., behind NAT) and omit `--public-addr` flag
+node_enable_public_ip_detection: true
 # It works only for the 'boot' mode!
 node_p2p_ws_port: "30334"
 ## prometheus

--- a/roles/node/handlers/main.yml
+++ b/roles/node/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: restart service {{ node_handler_id }}
   ansible.builtin.include_tasks: tasks/002-restart.yml
+  when: node_start_service | bool
 
 - name: health check {{ node_handler_id }}
   ansible.builtin.include_tasks: tasks/001-health-check.yml
+  when: node_start_service | bool

--- a/roles/node/molecule/default/group_vars/all.yml
+++ b/roles/node/molecule/default/group_vars/all.yml
@@ -3,6 +3,7 @@ ansible_user: root
 
 ## Node
 node_chain: polkadot
+node_app_name: "{{ node_chain }}"
 node_binary_version: v0.9.42
 node_binary: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot
 node_binary_signature: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot.asc

--- a/roles/node/molecule/default/verify.yml
+++ b/roles/node/molecule/default/verify.yml
@@ -24,27 +24,48 @@
       headers:
         Content-Type: 'application/json'
       use_proxy: false
+    until: _system_health_result.status is defined and _system_health_result.status == 200
+    retries: 3
+    delay: 10
     register: _system_health_result
 
-  - name: Print system_syncState
+  - name: Print system_health
     ansible.builtin.debug:
       msg: "{{ _system_health_result.json }}"
 
-  - name: re-deploy node with wipe
+  - name: Re-deploy node with additional parameters
     ansible.builtin.include_role:
       name: "node"
     vars:
-      node_db_wipe: true
+      node_database_wipe: true
       node_parachain_database_wipe: true
+      node_enable_public_ip_detection: false
+      node_start_service: false
 
-  - name: Collect service facts
+  - name: Collect service facts 1
     ansible.builtin.service_facts:
 
-  - name: Print service facts
+  - name: Print service facts 1
     ansible.builtin.debug:
       var: ansible_facts.services['polkadot.service']
 
-  - name: check service
+  - name: Check service 1
+    ansible.builtin.assert:
+      that: ansible_facts.services['polkadot.service'].state == 'stopped'
+
+  - name: Start {{ node_app_name }} service
+    ansible.builtin.systemd:
+      name: "{{ node_app_name }}"
+      state: "started"
+
+  - name: Collect service facts 2
+    ansible.builtin.service_facts:
+
+  - name: Print service facts 2
+    ansible.builtin.debug:
+      var: ansible_facts.services['polkadot.service']
+
+  - name: Check service 2
     ansible.builtin.assert:
       that: ansible_facts.services['polkadot.service'].state == 'running'
 
@@ -58,15 +79,14 @@
       headers:
         Content-Type: 'application/json'
       use_proxy: false
+    until: _system_health_result.status is defined and _system_health_result.status == 200
+    retries: 3
+    delay: 10
     register: _system_health_result
 
   - name: Print system_health
     ansible.builtin.debug:
       msg: "{{ _system_health_result.json }}"
-
-  - name: chain syncing
-    ansible.builtin.assert:
-      that: _system_health_result.json['result']['isSyncing']
 
   - name: Get system_syncState
     ansible.builtin.uri:

--- a/roles/node/tasks/002-restart.yml
+++ b/roles/node/tasks/002-restart.yml
@@ -8,4 +8,3 @@
     daemon_reload: yes
   notify: health check {{ node_handler_id }}
   ignore_errors: "{{ not _node_systemd_unit_file_stat.stat.exists }}"
-  when: node_start_service | bool

--- a/roles/node/tasks/002-restart.yml
+++ b/roles/node/tasks/002-restart.yml
@@ -8,3 +8,4 @@
     daemon_reload: yes
   notify: health check {{ node_handler_id }}
   ignore_errors: "{{ not _node_systemd_unit_file_stat.stat.exists }}"
+  when: node_start_service | bool

--- a/roles/node/tasks/900-systemd.yml
+++ b/roles/node/tasks/900-systemd.yml
@@ -7,6 +7,7 @@
   until: _node_ipify_result.failed is defined and not _node_ipify_result.failed
   retries: 3
   delay: 10
+  when: node_enable_public_ip_detection | bool
 
 - name: Systemd | Create directories
   ansible.builtin.file:
@@ -44,7 +45,7 @@
 - name: Systemd | Start {{ node_app_name }} service
   ansible.builtin.systemd:
     name: "{{ node_app_name }}"
-    state: started
+    state: "{{ 'started' if (node_start_service | bool) else 'stopped' }}"
     enabled: yes
     daemon_reload: yes
   notify: health check {{ node_handler_id }}

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -93,5 +93,5 @@
     file: 002-restart.yml
     apply:
       tags: ['node', 'node-restart']
-  when: node_force_restart | bool
+  when: node_start_service | bool and node_force_restart | bool
   tags: ['node', 'node-restart']

--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -37,8 +37,10 @@ RC_CHAIN="
 {%- endif %}"
 
 RC_ADDR="\
---listen-addr=/ip4/{{ node_p2p_bind_addr }}/tcp/{{ node_p2p_port }} \
---public-addr=/ip4/{{ ipify_public_ip }}/tcp/{{ node_p2p_public_port }}"
+--listen-addr=/ip4/{{ node_p2p_bind_addr }}/tcp/{{ node_p2p_port }}
+{%- if node_enable_public_ip_detection %} \
+--public-addr=/ip4/{{ ipify_public_ip }}/tcp/{{ node_p2p_public_port }}
+{%- endif %}"
 
 RC_CONNECTIONS="--in-peers {{ node_in_peers }} --out-peers {{ node_out_peers }}"
 
@@ -134,8 +136,10 @@ PC_CHAIN="
 {%- endif %}"
 
 PC_ADDR="\
---listen-addr=/ip4/{{ node_parachain_p2p_bind_addr }}/tcp/{{ node_parachain_p2p_port }} \
---public-addr=/ip4/{{ ipify_public_ip }}/tcp/{{ node_parachain_p2p_public_port }}"
+--listen-addr=/ip4/{{ node_parachain_p2p_bind_addr }}/tcp/{{ node_parachain_p2p_port }}
+{%- if node_enable_public_ip_detection %} \
+--public-addr=/ip4/{{ ipify_public_ip }}/tcp/{{ node_parachain_p2p_public_port }}
+{%- endif %}"
 
 PC_CONNECTIONS="--in-peers {{ node_parachain_in_peers }} --out-peers {{ node_parachain_out_peers }}"
 


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

- Add option to not immediately start the node. It is useful for building machine images (e.g., Amazon AMI) when service should only be started after the first boot.
- Add option to skip public IP detection for the same reason. A VM booted from a machine image can be assigned a random public IP not known in advance.