### PR TITLE
http backups were added to the node role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.0
+version: 1.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -103,32 +103,38 @@ node_custom_options: []
 node_enable_detailed_log_output: true
 
 ### Backup restoring
-## It works only for networks that have a sync node.
-# Can be "gcp", "tar" or "none". If it's "none", the role will not restore the blockstore of relaychain.
-# It will also not perform a restore if the db folder exists and is not empty,
-# unless `node_chain_backup_force_restoring` is enabled
+# Can be "http", "gcp", "tar" or "none". If it's "none", the role will not restore the blockstore of relaychain.
+# It will also not perform a restore if the db folder exists and is not empty
 node_chain_backup_restoring_type: none
 # Name of a folder that is used by different networks to store chain.
 # The role needs the variable to find the right path to restore a backup. It's equal a chain ID in a chainspec.
 # You can find some chain IDs in README.md
 node_chain_backup_chain_path: ""
-# Link to the tar backup file.
-# A tar archive must contain database on the root level
-node_chain_backup_url: ""
-# You can find the structure of a bucket in README.md
-node_chain_backup_gcp_bucket: ""
-# Link to a gcp backup, you have to specify a full path including a bucket name.
-node_chain_backup_gcp_path: ""
-# If you don't have pre-installed google SDK the role can install it
-node_chain_backup_gcp_install_sdk: false
-# If it's true, backup will be restored using the diff mode even if the 'db' folder exists.
-# It works only for diff sync restoring types, there is only one now - gcp.
-# It can be useful if you want to restore a broken db very quickly.
-node_chain_backup_force_restoring: false
 # Path where the backup will be downloaded to before it replaces the chain's db folder
 # In this way, we can avoid to stop the node service before downloading and it also allows you to
 # set the path to an additional (temporary) drive you have attached to the VM, should you need the extra space
 node_chain_backup_tmp_restore_path: ""
+
+## HTTP backups
+# link to HTTP backups
+node_chain_backup_http_base_url: "https://snapshots.polkadot.io"
+# full link to a HTTP backup
+node_chain_backup_http_url: ""
+# If you don't have pre-installed rclone the role can install it
+node_chain_backup_http_install_rclone: false
+
+## TAR backups
+# Link to the tar backup file.
+# A tar archive must contain database on the root level
+node_chain_backup_url: ""
+
+## GCP backups
+# You can find the structure of a bucket in README.md
+node_chain_backup_gcp_bucket: ""
+# full link to a GCP backup, you have to specify a full path including a bucket name.
+node_chain_backup_gcp_path: ""
+# If you don't have pre-installed google SDK the role can install it
+node_chain_backup_gcp_install_sdk: false
 
 ### Loging and telemetry
 node_telemetry_enable: true
@@ -202,26 +208,30 @@ node_parachain_custom_options: []
 #  - "--rpc-methods Unsafe"
 
 ### Backup restoring
-## It works only for polkadot, kusama, westend networks.
-# can be "gcp", "tar" or "none"
-# If it's "none", the role will not restore the blockstore of parachain
+# Can be "http", "gcp", "tar" or "none". If it's "none", the role will not restore the blockstore of parachain.
+# It will also not perform a restore if the db folder exists and is not empty
 node_parachain_chain_backup_restoring_type: none
 # Name of a folder that is used by different parachain networks to store chain.
 # The role needs the variable to find the right path to restore a backup. It's equal a chain ID in a chainspec.
 # You can find some chain IDs in README.md
 node_parachain_chain_backup_chain_path: ""
+
+## HTTP backups
+# link to HTTP backups
+node_parachain_chain_backup_http_base_url: "{{ node_chain_backup_http_base_url }}"
+# full link to a HTTP backup
+node_parachain_chain_backup_http_url: ""
+
+## TAR backups
 # Link to the tar backup file.
 # A tar archive must contain database on the root level
 node_parachain_chain_backup_url: ""
-# GCP bucket that contains backups. Format is 'gs://bucket-name/'.
+
+## GCP backups
 # You can find the structure of a bucket in README.md
 node_parachain_chain_backup_gcp_bucket: ""
 # Link to a gcp backup, you have to specify a full path including a bucket name.
 node_parachain_chain_backup_gcp_path: ""
-# If it's true, backup will be restored using the diff mode even if the 'db' folder exists.
-# It works only for diff sync restoring types, there is only one now - gcp.
-# It can be useful if you want to restore a broken db very quickly.
-node_parachain_chain_backup_force_restoring: false
 
 ### Loging and telemetry
 node_parachain_telemetry_enable: true

--- a/roles/node/molecule/default/group_vars/all.yml
+++ b/roles/node/molecule/default/group_vars/all.yml
@@ -4,7 +4,8 @@ ansible_user: root
 ## Node
 node_chain: polkadot
 node_app_name: "{{ node_chain }}"
-node_binary_version: v0.9.42
+node_binary_version: v0.9.43
+node_legacy_rpc_flags: false
 node_binary: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot
 node_binary_signature: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot.asc
 node_chain_backup_restoring_type: "none"

--- a/roles/node/molecule/default/group_vars/all.yml
+++ b/roles/node/molecule/default/group_vars/all.yml
@@ -6,6 +6,7 @@ node_chain: polkadot
 node_app_name: "{{ node_chain }}"
 node_binary_version: v0.9.43
 node_legacy_rpc_flags: false
+node_rpc_port: 9944
 node_binary: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot
 node_binary_signature: https://github.com/paritytech/polkadot/releases/download/{{ node_binary_version }}/polkadot.asc
 node_chain_backup_restoring_type: "none"

--- a/roles/node/molecule/default/verify.yml
+++ b/roles/node/molecule/default/verify.yml
@@ -16,7 +16,7 @@
 
   - name: Get system_health
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:9933'
+      url: 'http://127.0.0.1:{{ node_rpc_port }}'
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_health", "params":[]}
@@ -71,7 +71,7 @@
 
   - name: Get system_health
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:9933'
+      url: 'http://127.0.0.1:{{ node_rpc_port }}'
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_health", "params":[]}
@@ -90,7 +90,7 @@
 
   - name: Get system_syncState
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:9933'
+      url: 'http://127.0.0.1:{{ node_rpc_port }}'
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_syncState", "params":[]}

--- a/roles/node/molecule/default/verify.yml
+++ b/roles/node/molecule/default/verify.yml
@@ -16,7 +16,7 @@
 
   - name: Get system_health
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:{{ node_rpc_port }}'
+      url: "http://127.0.0.1:{{ node_rpc_port }}"
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_health", "params":[]}
@@ -71,7 +71,7 @@
 
   - name: Get system_health
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:{{ node_rpc_port }}'
+      url: "http://127.0.0.1:{{ node_rpc_port }}"
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_health", "params":[]}
@@ -90,7 +90,7 @@
 
   - name: Get system_syncState
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:{{ node_rpc_port }}'
+      url: "http://127.0.0.1:{{ node_rpc_port }}"
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_syncState", "params":[]}

--- a/roles/node/molecule/parachain/group_vars/all.yml
+++ b/roles/node/molecule/parachain/group_vars/all.yml
@@ -4,6 +4,8 @@ ansible_user: root
 # Common
 node_binary_version: v0.9.430
 node_legacy_rpc_flags: false
+node_rpc_port: 9944
+node_parachain_rpc_port: 9954
 node_binary: https://github.com/paritytech/cumulus/releases/download/{{ node_binary_version }}/polkadot-parachain
 node_binary_signature: https://github.com/paritytech/cumulus/releases/download/{{ node_binary_version }}/polkadot-parachain.asc
 node_app_name: "shell"

--- a/roles/node/molecule/parachain/group_vars/all.yml
+++ b/roles/node/molecule/parachain/group_vars/all.yml
@@ -2,7 +2,8 @@
 ansible_user: root
 
 # Common
-node_binary_version: v0.9.420
+node_binary_version: v0.9.430
+node_legacy_rpc_flags: false
 node_binary: https://github.com/paritytech/cumulus/releases/download/{{ node_binary_version }}/polkadot-parachain
 node_binary_signature: https://github.com/paritytech/cumulus/releases/download/{{ node_binary_version }}/polkadot-parachain.asc
 node_app_name: "shell"

--- a/roles/node/molecule/parachain/verify.yml
+++ b/roles/node/molecule/parachain/verify.yml
@@ -32,8 +32,8 @@
         Content-Type: 'application/json'
       use_proxy: false
     loop:
-      - 9933
-      - 9943
+      - {{ node_rpc_port }}
+      - {{ node_parachain_rpc_port }}
     register: _system_health_result
 
   - name: Print system_health
@@ -60,8 +60,8 @@
         Content-Type: 'application/json'
       use_proxy: false
     loop:
-      - 9933
-      - 9943
+      - {{ node_rpc_port }}
+      - {{ node_parachain_rpc_port }}
     register: _system_syncstate_result
 
   - name: Print system_syncState

--- a/roles/node/molecule/parachain/verify.yml
+++ b/roles/node/molecule/parachain/verify.yml
@@ -21,9 +21,9 @@
     ansible.builtin.assert:
       that: ansible_facts.services['shell.service'].state == 'running'
 
-  - name: Get system_health
+  - name: Get relaychain system_health
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:{{ item }}'
+      url: "http://127.0.0.1:{{ node_rpc_port }}"
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_health", "params":[]}
@@ -31,27 +31,43 @@
       headers:
         Content-Type: 'application/json'
       use_proxy: false
-    loop:
-      - "{{ node_rpc_port }}"
-      - "{{ node_parachain_rpc_port }}"
-    register: _system_health_result
+    until: _relaychain_system_health_result.status is defined and _relaychain_system_health_result.status == 200
+    retries: 3
+    delay: 10
+    register: _relaychain_system_health_result
+
+  - name: Get parachain system_health
+    ansible.builtin.uri:
+      url: "http://127.0.0.1:{{ node_parachain_rpc_port }}"
+      method: POST
+      body:
+        {"id":1, "jsonrpc":"2.0", "method":"system_health", "params":[]}
+      body_format: json
+      headers:
+        Content-Type: 'application/json'
+      use_proxy: false
+    until: _parachain_system_health_result.status is defined and _parachain_system_health_result.status == 200
+    retries: 3
+    delay: 10
+    register: _parachain_system_health_result
 
   - name: Print system_health
     ansible.builtin.debug:
       msg:
-        - "Relaychain: {{ _system_health_result.results[0].json }}"
-        - "Parachain: {{ _system_health_result.results[1].json }}"
+        - "Relaychain: {{ _relaychain_system_health_result.json }}"
+        - "Parachain: {{ _parachain_system_health_result.json }}"
 
   - name: relay chain syncing
     ansible.builtin.assert:
-      that: _system_health_result.results[0].json['result']['isSyncing']
+      that: _relaychain_system_health_result.json['result']['isSyncing']
+
   - name: parachain is not syncing (it is not onboarded)
     ansible.builtin.assert:
-      that: not _system_health_result.results[1].json['result']['isSyncing']
+      that: not _parachain_system_health_result.json['result']['isSyncing']
 
-  - name: Get system_syncState
+  - name: Get relaychain system_syncState
     ansible.builtin.uri:
-      url: 'http://127.0.0.1:{{ item }}'
+      url: "http://127.0.0.1:{{ node_rpc_port }}"
       method: POST
       body:
         {"id":1, "jsonrpc":"2.0", "method":"system_syncState", "params":[]}
@@ -59,13 +75,28 @@
       headers:
         Content-Type: 'application/json'
       use_proxy: false
-    loop:
-      - "{{ node_rpc_port }}"
-      - "{{ node_parachain_rpc_port }}"
-    register: _system_syncstate_result
+    until: _relaychain_system_syncstate_result.status is defined and _relaychain_system_syncstate_result.status == 200
+    retries: 3
+    delay: 10
+    register: _relaychain_system_syncstate_result
+
+  - name: Get parachain system_syncState
+    ansible.builtin.uri:
+      url: "http://127.0.0.1:{{ node_parachain_rpc_port }}"
+      method: POST
+      body:
+        {"id":1, "jsonrpc":"2.0", "method":"system_syncState", "params":[]}
+      body_format: json
+      headers:
+        Content-Type: 'application/json'
+      use_proxy: false
+    until: _parachain_system_syncstate_result.status is defined and _parachain_system_syncstate_result.status == 200
+    retries: 3
+    delay: 10
+    register: _parachain_system_syncstate_result
 
   - name: Print system_syncState
     ansible.builtin.debug:
       msg:
-        - "Relaychain: {{ _system_syncstate_result.results[0].json }}"
-        - "Parachain: {{ _system_syncstate_result.results[1].json }}"
+        - "Relaychain: {{ _relaychain_system_syncstate_result.json }}"
+        - "Parachain: {{ _parachain_system_syncstate_result.json }}"

--- a/roles/node/molecule/parachain/verify.yml
+++ b/roles/node/molecule/parachain/verify.yml
@@ -32,8 +32,8 @@
         Content-Type: 'application/json'
       use_proxy: false
     loop:
-      - {{ node_rpc_port }}
-      - {{ node_parachain_rpc_port }}
+      - "{{ node_rpc_port }}"
+      - "{{ node_parachain_rpc_port }}"
     register: _system_health_result
 
   - name: Print system_health
@@ -60,8 +60,8 @@
         Content-Type: 'application/json'
       use_proxy: false
     loop:
-      - {{ node_rpc_port }}
-      - {{ node_parachain_rpc_port }}
+      - "{{ node_rpc_port }}"
+      - "{{ node_parachain_rpc_port }}"
     register: _system_syncstate_result
 
   - name: Print system_syncState

--- a/roles/node/tasks/100-tests.yml
+++ b/roles/node/tasks/100-tests.yml
@@ -50,12 +50,12 @@
 - name: Test | Check node_chain_backup_restoring_type
   ansible.builtin.fail:
     msg: "The 'node_chain_backup_restoring_type' variable can contain only 'gcp', 'tar' or 'none' values!"
-  when: node_chain_backup_restoring_type not in ["gcp", "tar", "none"]
+  when: node_chain_backup_restoring_type not in ["http", "gcp", "tar", "none"]
 
 - name: Test | Check node_parachain_chain_backup_restoring_type
   ansible.builtin.fail:
     msg: "The 'node_parachain_chain_backup_restoring_type' variable can contain only 'gcp', 'tar' or 'none' values!"
-  when: node_parachain_chain_backup_restoring_type not in ["gcp", "tar", "none"]
+  when: node_parachain_chain_backup_restoring_type not in ["http", "gcp", "tar", "none"]
 
 - name: Test | Check gcp backup
   ansible.builtin.fail:
@@ -63,18 +63,6 @@
     pruning state: {{ (node_pruning > 0) }}, 
     you have to set the node_chain_backup_gcp_bucket variable or the node_chain_backup_gcp_path"
   when: node_chain_backup_restoring_type == 'gcp' and node_chain_backup_gcp_bucket == '' and node_chain_backup_gcp_path == ''
-
-  # Should just function as a warning in check mode
-- name: Test | Check if node_chain_backup_force_restoring is enabled without a custom path
-  ansible.builtin.fail:
-    msg: |
-      node_chain_backup_force_restoring is enabled without node_chain_backup_tmp_restore_path being set. 
-      This could cause long downtime if the backup size is huge
-  when:
-    - node_chain_backup_force_restoring
-    - node_chain_backup_tmp_restore_path == ''
-    - ansible_check_mode
-  ignore_errors: true
 
 - name: Test | Check parachain gcp backup
   ansible.builtin.fail:

--- a/roles/node/tasks/1000-post-tasks.yml
+++ b/roles/node/tasks/1000-post-tasks.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Post tasks | Remove temporary directory
+  ansible.builtin.file:
+    path: "{{ _node_temp_dir.path }}"
+    state: absent
+  check_mode: false
+  changed_when: false
+  when: _node_temp_dir.path is defined

--- a/roles/node/tasks/200-prepare.yml
+++ b/roles/node/tasks/200-prepare.yml
@@ -32,3 +32,11 @@
 - name: Prepare | Print _node_memory_profiler_log_path
   ansible.builtin.debug:
     var: _node_memory_profiler_log_path
+
+- name: Prepare | Create temporary directory
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: polkadot_temp_dir
+  register: _node_temp_dir
+  check_mode: false
+  changed_when: false

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -8,14 +8,6 @@
     owner: "{{ node_user }}"
     group: "{{ node_user }}"
 
-- name: Binary | Create temporary directory
-  ansible.builtin.tempfile:
-    state: directory
-    suffix: polkadot_temp_binary
-  register: _node_temp_dir
-  check_mode: false
-  changed_when: false
-
 - name: Binary | Setup _node_temp_binary variable
   ansible.builtin.set_fact:
     _node_temp_binary_file: "{{ _node_temp_dir.path }}/{{ node_app_name }}"
@@ -113,14 +105,6 @@
     group: "{{ node_user }}"
   notify: restart service {{ node_handler_id }}
   ignore_errors: "{{ not _node_binary_path_stat.stat.exists }}"
-
-- name: Binary | Delete temporary directory
-  ansible.builtin.file:
-    path: "{{ _node_temp_dir.path }}"
-    state: absent
-  check_mode: false
-  changed_when: false
-  when: _node_temp_dir.path is defined
 
 - name: Binary | Block
   block:

--- a/roles/node/tasks/800-restore-chain.yml
+++ b/roles/node/tasks/800-restore-chain.yml
@@ -21,8 +21,7 @@
 - name: Restore {{ item.part }} | Set custom facts 1
   ansible.builtin.set_fact:
     _node_run_restore: "{{ not _node_data_chain_path_db_stat.stat.exists or
-                           _node_data_chain_path_db_size.stdout == '0' or
-                           item.force_restoring }}"
+                           _node_data_chain_path_db_size.stdout == '0' }}"
     # we only use the tmp_restore_path directory if we really need it (when a service is run)
     _node_use_tmp_restore_path: "{{ ansible_facts.services[node_app_name+'.service'] is defined and
                                     ansible_facts.services[node_app_name+'.service'].state == 'running' and 
@@ -38,8 +37,7 @@
     # We don't need to calculate free space if we sync  a backup to an existing DB
     # Because we can't know the required amount of free space before syncing
     _node_run_check_size: "{{ not (_node_data_chain_path_db_stat.stat.exists and 
-                              _node_data_chain_path_db_size.stdout != '0' and 
-                              item.force_restoring and
+                              _node_data_chain_path_db_size.stdout != '0' and
                               not _node_use_tmp_restore_path) and 
                               _node_run_check_size_mounts | length > 0  }}"
     _node_backup_dl_path: "{{ node_chain_backup_tmp_restore_path if _node_use_tmp_restore_path 
@@ -71,7 +69,7 @@
       _node_restore_free_space: "{{ _node_run_check_size_mounts[-1]['size_available'] }}"
     when: _node_run_check_size
 
-  - name: Restore {{ item.part }} | GCP restoring | Print free space in '_node_data_root_path'
+  - name: Restore {{ item.part }} | Print free space in '_node_data_root_path'
     ansible.builtin.debug:
       msg: Free space at destination = {{ _node_restore_free_space | filesizeformat(true) }}
     when: _node_run_check_size
@@ -81,7 +79,7 @@
       file: 801-restore-chain-tar.yml
       apply:
         tags: [ 'node', 'node-restore-chain' ]
-    when: item.restoring_type == 'tar' and not item.force_restoring
+    when: item.restoring_type == 'tar'
 
   - name: Restore {{ item.part }} | GCP restoring
     ansible.builtin.include_tasks:
@@ -89,6 +87,13 @@
       apply:
         tags: [ 'node', 'node-restore-chain' ]
     when:  item.restoring_type == 'gcp'
+
+  - name: Restore {{ item.part }} | HTTP restoring
+    ansible.builtin.include_tasks:
+      file: 803-restore-chain-http.yml
+      apply:
+        tags: [ 'node', 'node-restore-chain' ]
+    when:  item.restoring_type == 'http'
 
   - name: Restore {{ item.part }} | Check if data_root folder already exists
     ansible.builtin.stat:

--- a/roles/node/tasks/802-restore-chain-gcp.yml
+++ b/roles/node/tasks/802-restore-chain-gcp.yml
@@ -25,17 +25,17 @@
   when: node_chain_backup_gcp_install_sdk | bool
 
 - name: Restore {{ item.part }} | GCP restoring | Check last version
-  ansible.builtin.command: gsutil cat {{ item.gcp_path }}/latest_version.meta.txt
+  ansible.builtin.command: gsutil cat {{ item.gcp_url }}/latest_version.meta.txt
   register: _node_last_backup_version
   check_mode: false
   changed_when: false
-  when: item.custom_gcp_path == ''
+  when: item.custom_gcp_url == ''
 
 - name: Restore {{ item.part }} | GCP restoring | Setup _node_chain_backup_gcp_full_path
   ansible.builtin.set_fact:
-    _node_chain_backup_gcp_full_path: "{% if item.custom_gcp_path == '' %}
-    {{ item.gcp_path }}/{{ _node_last_backup_version.stdout }}
-    {% else %}{{ item.custom_gcp_path }}{% endif %}"
+    _node_chain_backup_gcp_full_path: "{% if item.custom_gcp_url == '' %}
+    {{ item.gcp_url }}/{{ _node_last_backup_version.stdout }}
+    {% else %}{{ item.custom_gcp_url }}{% endif %}"
 
 - name: Restore {{ item.part }} | GCP restoring | Check the size of the backup
   ansible.builtin.shell: gsutil du -s {{ _node_chain_backup_gcp_full_path | trim | quote }} | awk '{print $1}'
@@ -52,9 +52,8 @@
 - name: Restore {{ item.part }} | GCP restoring | Fail if free space <500MB
   ansible.builtin.fail:
     msg: |
-      Not enough free space to perform the restore, you should set the node_chain_restore_custom_path variable
-      to a path on a different drive with enough free space or enable node_chain_backup_force_restoring
-      to overwrite the original db
+      Not enough free space to perform the restore, you should set the node_data_root_path variable
+      to a path on a different drive with enough free space
   when:
     - _node_run_check_size
     - _node_restore_free_space | int - _node_restore_backup_size.stdout | int < 500 * 1024 * 1024

--- a/roles/node/tasks/803-restore-chain-http.yml
+++ b/roles/node/tasks/803-restore-chain-http.yml
@@ -1,0 +1,119 @@
+---
+
+
+- name: Restore {{ item.part }} | HTTP restoring  | Install rclone
+  ansible.builtin.apt:
+    deb: "{{ _node_chain_backup_http_rclone_deb }}"
+  when: node_chain_backup_http_install_rclone | bool
+
+- name: Restore {{ item.part }} | HTTP restoring | Check last version
+  ansible.builtin.uri:
+    url: "{{ item.http_url | trim | trim('/') }}/latest_version.meta.txt"
+    method: "GET"
+    return_content: yes
+    use_proxy: false
+  register: _node_chain_backup_last_version_register
+  until: _node_chain_backup_last_version_register.status is defined and
+         _node_chain_backup_last_version_register.status == 200
+  retries: 3
+  delay: 10
+  check_mode: false
+  changed_when: false
+  when: item.custom_http_url == ''
+
+- name: Restore {{ item.part }} | HTTP restoring | Setup _node_chain_backup_http_full_url 1
+  ansible.builtin.set_fact:
+    _node_chain_backup_http_full_url: "{% if item.custom_http_url == '' %}
+    {{ item.http_url }}/{{ _node_chain_backup_last_version_register.content }}
+    {% else %}{{ item.custom_http_url }}{% endif %}"
+
+- name: Restore {{ item.part }} | HTTP restoring | Setup _node_chain_backup_http_full_url 2
+  ansible.builtin.set_fact:
+    _node_chain_backup_http_full_url: "{{ _node_chain_backup_http_full_url | regex_replace('[\\s]+','') | trim('/') }}"
+
+- name: Restore {{ item.part }} | HTTP restoring | Print backup url
+  ansible.builtin.debug:
+    msg: "{{ _node_chain_backup_http_full_url }}"
+
+- name: Restore {{ item.part }} | HTTP restoring | Print backup meta url
+  ansible.builtin.debug:
+    msg: "{{ _node_chain_backup_http_full_url }}.meta.txt"
+
+- name: Restore {{ item.part }} | HTTP restoring | Check the size of the backup
+  ansible.builtin.uri:
+    url: "{{ _node_chain_backup_http_full_url }}.meta.txt"
+    method: "GET"
+    return_content: yes
+    use_proxy: false
+  register: _node_chain_restore_backup_size_register
+  until: _node_chain_restore_backup_size_register.status is defined and
+         _node_chain_restore_backup_size_register.status == 200
+  retries: 3
+  delay: 10
+  check_mode: false
+  changed_when: false
+  when: _node_run_check_size
+
+- name: Restore {{ item.part }} | HTTP restoring | Print backup size
+  ansible.builtin.debug:
+    msg: "Backup size = {{ (_node_chain_restore_backup_size_register.content | from_yaml).size | int | filesizeformat(true) }}"
+  when: _node_run_check_size
+
+- name: Restore {{ item.part }} | HTTP restoring | Fail if free space <500MB
+  ansible.builtin.fail:
+    msg: |
+      Not enough free space to perform the restore, you should set the node_data_root_path variable
+      to a path on a different drive with enough free space
+  when:
+    - _node_run_check_size
+    - _node_restore_free_space | int - (_node_chain_restore_backup_size_register.content | from_yaml).size | int < 500 * 1024 * 1024
+    # Skipped during check mode because it doesn't actually delete the db, making the result of this task wrong
+    - not ansible_check_mode
+
+- name: Restore {{ item.part }} | HTTP restoring | Download the files.txt meta file
+  ansible.builtin.get_url:
+    url: "{{ _node_chain_backup_http_full_url }}/files.txt"
+    dest: "{{ _node_temp_dir.path }}/{{ item.part }}-files.txt"
+    mode: 0755
+    owner: "root"
+    group: "root"
+    timeout: 30
+  check_mode: false
+  changed_when: false
+
+- name: Restore {{ item.part }} | HTTP restoring | Stop service
+  ansible.builtin.systemd:
+    name: "{{ node_app_name }}"
+    state: stopped
+  notify: restart service {{ node_handler_id }}
+  ignore_errors: "{{ not _node_systemd_unit_file_stat.stat.exists }}"
+  when: not _node_use_tmp_restore_path
+
+- name: Restore {{ item.part }} | HTTP restoring | Download chain backup
+  ansible.builtin.command: |
+    rclone copy -v --contimeout=1m --retries 6 --retries-sleep 10 --disable-http2 --http-no-head --no-traverse
+    --transfers={{ ansible_processor_vcpus * 5 }} --http-url {{ _node_chain_backup_http_full_url }} :http:
+    {{ _node_backup_dl_path | quote }} --files-from-raw {{ _node_temp_dir.path }}/{{ item.part }}-files.txt
+  changed_when: true
+  notify: restart service {{ node_handler_id }}
+
+- name: Restore {{ item.part }} | HTTP restoring | Manage node_chain_backup_tmp_restore_path
+  block:
+
+  - name: Restore {{ item.part }} | GCP restoring | Stop service and cleanup DB
+    ansible.builtin.include_tasks: includes/_delete_db_folder.yml
+
+  - name: Restore {{ item.part }} | HTTP restoring | Copy backup from temporary folder
+    ansible.builtin.copy:
+      src: "{{ node_chain_backup_tmp_restore_path }}/"
+      dest: "{{ item.chain_path }}/{{ item.db_folder }}"
+      owner: "{{ node_user }}"
+      group: "{{ node_user }}"
+      remote_src: true
+
+  - name: Restore {{ item.part }} | HTTP restoring | Delete temporary folder
+    ansible.builtin.file:
+      path: "{{ node_chain_backup_tmp_restore_path }}"
+      state: absent
+
+  when: _node_use_tmp_restore_path

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -11,14 +11,14 @@
   ansible.builtin.stat:
     path: "{{ _node_unit_file }}"
   register: _node_systemd_unit_file_stat
-  tags: ['node', 'node-wipe', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart']
+  tags: ['node', 'node-wipe', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart', 'node-post-tasks']
 
 - name: node | Prepare
   ansible.builtin.include_tasks:
     file: 200-prepare.yml
     apply:
-      tags: ['node', 'node-prepare', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart']
-  tags: ['node', 'node-prepare', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart']
+      tags: ['node', 'node-prepare', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart', 'node-post-tasks']
+  tags: ['node', 'node-prepare', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart', 'node-post-tasks']
 
 - name: node | Wipe
   ansible.builtin.include_tasks:
@@ -95,3 +95,10 @@
       tags: ['node', 'node-restart']
   when: node_start_service | bool and node_force_restart | bool
   tags: ['node', 'node-restart']
+
+- name: node | Post tasks
+  ansible.builtin.include_tasks:
+    file: 1000-post-tasks.yml
+    apply:
+      tags: ['node', 'node-prepare', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart', 'node-post-tasks']
+  tags: ['node', 'node-prepare', 'node-health-check', 'node-binary', 'node-memory-profiler', 'node-chain', 'node-restore-chain', 'node-systemd', 'node-restart', 'node-post-tasks']

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -27,8 +27,7 @@ _node_memory_profiler_binary_file: "{{ _node_binary_path }}/libbytehound.so"
 _node_wasm_runtime_base_path: "{{ _node_user_home_path }}/wasm_runtime/{{ node_app_name }}"
 _node_unit_file: "/etc/systemd/system/{{ node_app_name }}.service"
 
-_node_subkey_url: https://releases.parity.io/substrate/x86_64-debian%3Astretch/v3.0.0/subkey/subkey
-_node_subkey_local_path: "{{ _node_binary_path }}/subkey"
+_node_chain_backup_http_rclone_deb: "https://downloads.rclone.org/v1.62.2/rclone-v1.62.2-linux-amd64.deb"
 
 _node_profiles:
   validator:
@@ -73,20 +72,25 @@ _node_p2p_key_file: "{{ _node_user_home_path }}/keys/{{ node_app_name }}_relaych
 _node_chainspec_file: "{{ _node_user_home_path }}/chainspecs/{{ node_app_name }}_relaychain_chainspec.json"
 
 _node_restore_relaychain: "{{
+                            (node_chain_backup_restoring_type == 'http' and ( node_chain_backup_http_base_url != '' or node_chain_backup_http_url != '')) or
                             (node_chain_backup_restoring_type == 'gcp' and ( node_chain_backup_gcp_bucket != '' or node_chain_backup_gcp_path != '')) or
                             (node_chain_backup_restoring_type == 'tar' and node_chain_backup_url != '')
                             }}"
 _node_chain_backup_data:
   part: relaychain
   restoring_type: "{{ node_chain_backup_restoring_type }}"
-  force_restoring: "{{ node_chain_backup_force_restoring }}"
   chain_path: "{{ _node_data_chain_path }}"
+  db_folder: "{{ 'paritydb' if node_paritydb_enable else 'db' }}"
   tar_url: "{{ node_chain_backup_url }}"
-  gcp_path: "{{ node_chain_backup_gcp_bucket +
+  gcp_url: "{{ node_chain_backup_gcp_bucket +
   node_chain +
   ('-paritydb' if node_paritydb_enable else '-rocksdb') + ('-prune' if node_pruning > 0 else '-archive') }}"
-  custom_gcp_path: "{{ node_chain_backup_gcp_path }}"
-  db_folder: "{{ 'paritydb' if node_paritydb_enable else 'db' }}"
+  custom_gcp_url: "{{ node_chain_backup_gcp_path }}"
+  http_url: "{{ node_chain_backup_http_base_url + '/' +
+  node_chain +
+  ('-paritydb' if node_paritydb_enable else '-rocksdb') + ('-prune' if node_pruning > 0 else '-archive') }}"
+  custom_http_url: "{{ node_chain_backup_http_url }}"
+
 
 
 #####################################################################################
@@ -98,17 +102,22 @@ _node_parachain_p2p_key_file: "{{ _node_user_home_path }}/keys/{{ node_app_name 
 _node_parachain_chainspec_file: "{{ _node_user_home_path }}/chainspecs/{{ node_app_name }}_parachain_chainspec.json"
 
 _node_restore_parachain: "{{ node_parachain_role != '' and
-                            ((node_parachain_chain_backup_restoring_type == 'gcp' and (node_parachain_chain_backup_gcp_bucket != '' or node_parachain_chain_backup_gcp_path != '' )) or
+                            ((node_parachain_chain_backup_restoring_type == 'http' and (node_parachain_chain_backup_http_base_url != '' or node_parachain_chain_backup_http_url != '' )) or
+                            (node_parachain_chain_backup_restoring_type == 'gcp' and (node_parachain_chain_backup_gcp_bucket != '' or node_parachain_chain_backup_gcp_path != '' )) or
                             (node_parachain_chain_backup_restoring_type == 'tar' and node_parachain_chain_backup_url != ''))
                             }}"
 _node_parachain_chain_backup_data:
   part: parachain
   restoring_type: "{{ node_parachain_chain_backup_restoring_type }}"
-  force_restoring: "{{ node_parachain_chain_backup_force_restoring }}"
   chain_path: "{{ _node_parachain_data_chain_path }}"
+  db_folder: "{{ 'paritydb' if node_parachain_paritydb_enable else 'db' }}"
   tar_url: "{{ node_parachain_chain_backup_url }}"
-  gcp_path: "{{ node_parachain_chain_backup_gcp_bucket +
+  gcp_url: "{{ node_parachain_chain_backup_gcp_bucket +
   node_parachain_chain +
   ('-paritydb' if node_parachain_paritydb_enable else '-rocksdb') + ('-prune' if node_parachain_pruning > 0 else '-archive') }}"
-  custom_gcp_path: "{{ node_parachain_chain_backup_gcp_path }}"
-  db_folder: "{{ 'paritydb' if node_parachain_paritydb_enable else 'db' }}"
+  custom_gcp_url: "{{ node_parachain_chain_backup_gcp_path }}"
+  http_url: "{{ node_parachain_chain_backup_http_base_url + '/' +
+  node_parachain_chain +
+  ('-paritydb' if node_parachain_paritydb_enable else '-rocksdb') + ('-prune' if node_parachain_pruning > 0 else '-archive') }}"
+  custom_http_url: "{{ node_parachain_chain_backup_http_url }}"
+


### PR DESCRIPTION
* node_chain_backup_force_restoring option was removed, because only GCP backups support it
* HTTP backup feature was added. It uses rclone to download files. It goes through a list of all files and downloads it in parallel mode. The list is stored as a separate meta-file
* molecule tests were fixed