### PR TITLE
Change CLI flags in Polkadot release v0.9.43

### DIFF
--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -18,7 +18,7 @@ RC_ROLE_SPECIFIC="\
 --validator
 {%- elif node_role == 'rpc' %}
 {% if node_legacy_rpc_flags %}
---unsafe-ws-external \
+--unsafe-rpc-external \
 {% else %}
 --unsafe-rpc-external \
 {% endif %}
@@ -81,8 +81,8 @@ RC_METRICS="\
 
 RC_WS="\
 {% if node_legacy_rpc_flags %}
---ws-port {{ node_rpc_ws_port }} \
---ws-max-connections {{ node_ws_max_connections }}
+--rpc-port {{ node_rpc_ws_port }} \
+--rpc-max-connections {{ node_ws_max_connections }}
 {%- else %}
 --rpc-max-connections {{ node_ws_max_connections }}
 {%- endif %}"
@@ -119,7 +119,7 @@ PC_ROLE_SPECIFIC="\
 --validator
 {%- elif node_parachain_role == 'rpc' %}
 {% if node_legacy_rpc_flags %}
---unsafe-ws-external \
+--unsafe-rpc-external \
 {% else %}
 --unsafe-rpc-external \
 {% endif %}
@@ -180,8 +180,8 @@ PC_METRICS="\
 
 PC_WS="\
 {% if node_legacy_rpc_flags %}
---ws-port {{ node_parachain_rpc_ws_port }} \
---ws-max-connections {{ node_parachain_ws_max_connections }}
+--rpc-port {{ node_parachain_rpc_ws_port }} \
+--rpc-max-connections {{ node_parachain_ws_max_connections }}
 {%- else %}
 --rpc-max-connections {{ node_parachain_ws_max_connections }}
 {%- endif %}"


### PR DESCRIPTION
small correction to the CLI flags, as issued in #37 