### PR TITLE
Adapt to new polkadot binaries split

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           channel: latest/stable
       - name: Setup Python modules
-        run: pip3 install yamllint ansible ansible-lint molecule molecule-plugins[docker] molecule-lxd docker
+        run: pip3 install PyYAML==5.3.1 yamllint ansible ansible-lint molecule molecule-plugins[docker] molecule-lxd docker
       - name: Run molecule
         run: molecule test --all
         working-directory: "${{ github.repository }}/${{ inputs.role-path }}"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: parity
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.4.0
+version: 1.5.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/key_inject/tasks/inject.yml
+++ b/roles/key_inject/tasks/inject.yml
@@ -28,7 +28,7 @@
 
     - name: Inject | Check {{ item.type }} key results
       ansible.builtin.debug:
-        msg: "Key {{ key_inject_pub_key }} ({{ item.type }}, {{ tem.scheme | default('sr25519') }}) is {{ 'NOT ' if not key_inject_uri.json.result else '' }}present in keystore"
+        msg: "Key {{ key_inject_pub_key }} ({{ item.type }}, {{ item.scheme | default('sr25519') }}) is {{ 'NOT ' if not key_inject_uri.json.result else '' }}present in keystore"
       changed_when: not key_inject_uri.json.result
 
     - name: Inject | Inject {{ item.type }} keys

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -22,7 +22,7 @@ node_binary_signature: ""
 
 # Set it to true if Polkadot uses separate binaries: https://github.com/paritytech/polkadot/pull/7337
 node_separate_binary: false
-# List of binders to download if node_separate_binary is True.
+# List of binaries to download if node_separate_binary is True.
 # The first element is the main binary, and the rest are auxiliary binaries.
 node_separate_binary_list:
   - polkadot

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -20,6 +20,16 @@ node_binary_release_key_id: 9D4B2B6EB8F97156D19669A9FF0812D491B96798
 # GPG signature URL. When left empty, binary verification will not be executed
 node_binary_signature: ""
 
+# Set it to true if Polkadot uses separate binaries: https://github.com/paritytech/polkadot/pull/7337
+node_separate_binary: false
+# List of binders to download if node_separate_binary is True.
+# The first element is the main binary, and the rest are auxiliary binaries.
+node_separate_binary_list:
+  - polkadot
+  - polkadot-prepare-worker
+  - polkadot-execute-worker
+
+
 ### Node preferences
 # You can redefine any variables from playbooks directly
 # Values from the "_node_profiles" are used by default

--- a/roles/node/tasks/100-tests.yml
+++ b/roles/node/tasks/100-tests.yml
@@ -5,6 +5,13 @@
     msg: "The 'node_binary' variable can't be empty!"
   when: node_binary == ''
 
+- name: Test | Check if separate binary
+  ansible.builtin.fail:
+    msg: "If 'node_separate_binary' is True, 'node_binary' and 'node_binary_signature' should end with '/'"
+  when:
+    - node_separate_binary
+    - not node_binary.endswith('/')
+
 - name: Test | Check if node_binary_signature is a URL
   ansible.builtin.fail:
     msg: "The 'node_binary_signature' variable must be a URL!"

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -136,9 +136,8 @@
       changed_when: false
     - name: Binary | Setup supported flags
       ansible.builtin.set_fact:
-        _node_legacy_rpc_flags_supported: "{{ '--ws-port' in _node_new_help }}"
-        _node_separate_binary_supported: "{{ '--workers-path' in _node_new_help }}"
-
+        _node_legacy_rpc_flags_supported: "{{ '--ws-port' in _node_new_help.stdout }}"
+        _node_separate_binary_supported: "{{ '--workers-path' in _node_new_help.stdout }}"
     - name: Binary | Check new rpc flags
       ansible.builtin.fail:
         msg: "ERROR: RPC flag --ws-port {{ 'IS' if _node_legacy_rpc_flags_supported else 'NOT' }} supported. 'node_legacy_rpc_flags' should be set to {{ _node_legacy_rpc_flags_supported }}"
@@ -174,7 +173,7 @@
 - name: Binary | Copy new auxiliary binaries
   ansible.builtin.copy:
     src: "{{ _node_temp_dir.path }}/{{ item }}"
-    dest: {{ _node_binary_path }}/{{ item }}"
+    dest: "{{ _node_binary_path }}/{{ item }}"
     remote_src: yes
     mode: 0755
     owner: "{{ node_user }}"

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -12,9 +12,9 @@
   ansible.builtin.set_fact:
     _node_temp_binary_file: "{{ _node_temp_dir.path }}/{{ node_app_name }}"
 
-- name: Binary | Download binary
+- name: Binary | Download main binary
   ansible.builtin.get_url:
-    url: "{{ node_binary }}"
+    url: "{{ node_binary }}{{ node_separate_binary_list[0] if node_separate_binary else ''}}"
     dest: "{{ _node_temp_binary_file }}"
     mode: 0755
     owner: "root"
@@ -25,15 +25,39 @@
   check_mode: false
   changed_when: false
 
+- name: Binary | Download auxiliary binaries
+  ansible.builtin.get_url:
+    url: "{{ node_binary }}{{ item }}"
+    dest: "{{ _node_temp_dir.path }}"
+    mode: 0755
+    owner: "root"
+    group: "root"
+    timeout: 30
+    headers:
+      PRIVATE-TOKEN: "{{ node_binary_download_private_token }}"
+  check_mode: false
+  changed_when: false
+  when: node_separate_binary
+  loop: "{{ node_separate_binary_list[1:] }}"
+
 - name: Binary | GPG signature verification
   block:
 
-    - name: Binary | Download GPG signature
+    - name: Binary | Download GPG signature for main binary
       ansible.builtin.get_url:
-        url: "{{ node_binary_signature }}"
+        url: "{{ node_binary_signature }}{{ node_separate_binary_list[0] + '.asc' if node_separate_binary else ''}}"
         dest: "{{ _node_temp_dir.path }}/{{ node_app_name }}.asc"
       check_mode: false
       changed_when: false
+
+    - name: Binary | Download GPG signature for auxiliary binaries
+      ansible.builtin.get_url:
+        url: "{{ node_binary_signature }}{{ item }}.asc"
+        dest: "{{ _node_temp_dir.path }}/{{ item }}.asc"
+      check_mode: false
+      changed_when: false
+      when: node_separate_binary
+      loop: "{{ node_separate_binary_list[1:] }}"
 
     - name: Binary | Import release GPG public key
       ansible.builtin.command: |
@@ -43,13 +67,23 @@
       failed_when: _node_keyout.rc != 0
       check_mode: false
 
-    - name: Binary | Verify GPG signature
+    - name: Binary | Verify GPG signature for main binary
       ansible.builtin.command: |
         {{ _node_binary_gpg_binary }} --verify {{ _node_temp_dir.path }}/{{ node_app_name }}.asc
       register: _node_verifyout
       check_mode: false
       changed_when: false
       failed_when: _node_verifyout.rc != 0
+
+    - name: Binary | Verify GPG signature for auxiliary binaries
+      ansible.builtin.command: |
+        {{ _node_binary_gpg_binary }} --verify {{ _node_temp_dir.path }}/{{ item }}.asc
+      register: _node_verifyout
+      check_mode: false
+      changed_when: false
+      failed_when: _node_verifyout.rc != 0
+      when: node_separate_binary
+      loop: "{{ node_separate_binary_list[1:] }}"
 
   when: node_binary_signature != ''
 
@@ -93,9 +127,40 @@
     path: "{{ _node_binary_file | dirname }}"
   register: _node_binary_path_stat
 
+- name: Binary | Migration between versions
+  block:
+    - name: Binary | Check new version
+      ansible.builtin.command: "{{ _node_temp_binary_file }} --help"
+      register: _node_new_help
+      check_mode: false
+      changed_when: false
+    - name: Binary | Setup supported flags
+      ansible.builtin.set_fact:
+        _node_legacy_rpc_flags_supported: "{{ '--ws-port' in _node_new_help }}"
+        _node_separate_binary_supported: "{{ '--workers-path' in _node_new_help }}"
+
+    - name: Binary | Check new rpc flags
+      ansible.builtin.fail:
+        msg: "ERROR: RPC flag --ws-port {{ 'IS' if _node_legacy_rpc_flags_supported else 'NOT' }} supported. 'node_legacy_rpc_flags' should be set to {{ _node_legacy_rpc_flags_supported }}"
+      when:
+        # XOR (skip fail if both true or both false)
+        - node_legacy_rpc_flags or _node_legacy_rpc_flags_supported
+        - not (node_legacy_rpc_flags and _node_legacy_rpc_flags_supported)
+
+    - name: Binary | Check new rpc flags
+      ansible.builtin.fail:
+        msg: >
+          ERROR: RPC flag --workers-path {{ 'IS' if _node_separate_binary_supported else 'NOT' }} supported. 
+          'node_separate_binary' should be set to {{ _node_separate_binary_supported }, 
+          you may also need to update the 'node_binary' and 'node_separate_binary_list' variables.
+      when:
+        # XOR (skip fail if both true or both false)
+        - node_separate_binary or _node_separate_binary_supported
+        - not (node_separate_binary and _node_separate_binary_supported)
+
 # We don't need checking of hashes. The copy module does it itself.
 # If you have the same binary file you will see a green check in the check mode.
-- name: Binary | Copy new binary
+- name: Binary | Copy new main binary
   ansible.builtin.copy:
     src: "{{ _node_temp_binary_file }}"
     dest: "{{ _node_binary_file }}"
@@ -105,6 +170,19 @@
     group: "{{ node_user }}"
   notify: restart service {{ node_handler_id }}
   ignore_errors: "{{ not _node_binary_path_stat.stat.exists }}"
+
+- name: Binary | Copy new auxiliary binaries
+  ansible.builtin.copy:
+    src: "{{ _node_temp_dir.path }}/{{ item }}"
+    dest: {{ _node_binary_path }}/{{ item }}"
+    remote_src: yes
+    mode: 0755
+    owner: "{{ node_user }}"
+    group: "{{ node_user }}"
+  notify: restart service {{ node_handler_id }}
+  ignore_errors: "{{ not _node_binary_path_stat.stat.exists }}"
+  when: node_separate_binary
+  loop: "{{ node_separate_binary_list[1:] }}"
 
 - name: Binary | Block
   block:

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -146,11 +146,11 @@
         - node_legacy_rpc_flags or _node_legacy_rpc_flags_supported
         - not (node_legacy_rpc_flags and _node_legacy_rpc_flags_supported)
 
-    - name: Binary | Check new rpc flags
+    - name: Binary | Check new worker flags
       ansible.builtin.fail:
         msg: >
-          ERROR: RPC flag --workers-path {{ 'IS' if _node_separate_binary_supported else 'NOT' }} supported. 
-          'node_separate_binary' should be set to {{ _node_separate_binary_supported }, 
+          ERROR: node flag --workers-path {{ 'IS' if _node_separate_binary_supported else 'NOT' }} supported. 
+          'node_separate_binary' should be set to {{ _node_separate_binary_supported }}, 
           you may also need to update the 'node_binary' and 'node_separate_binary_list' variables.
       when:
         # XOR (skip fail if both true or both false)


### PR DESCRIPTION
Fixes https://github.com/paritytech/ansible-galaxy/issues/40

## Changes:

1. Fixed a typo in the key inject role.
2. Adapted to the new binary split for validators.
3. Added migration checks: After downloading the new binary, the help command is used to verify the presence of necessary flags. We check `--help` output instead of the `--version` since the role may deploy any Substrate chain, and the version format can vary.

## Tests

I used a binary from the master branch (link may have expired): [Binary Link](https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/3348105/artifacts/browse/artifacts/)

**Case 1:**
Using the old ansible role results in a failure:

```
2023-08-08 16:37:33.992  WARN tokio-runtime-worker sc_service::builder: The NetworkStart returned as part of `build_network` has been silently dropped
Error:
   0: Worker binaries could not be found. Ensure that polkadot was built/installed correctly. Searched given workers path (None), polkadot binary path ("/home/parity/bin"), and lib path (/usr/lib/polkadot), worker names: None
```

**Case 2:**
Using the new ansible role from this branch results in successful application execution:

```
2023-08-08 16:31:26.134  INFO main polkadot_service: 🚀 Using the prepare-worker binary at: "/home/parity/bin/polkadot-prepare-worker"
2023-08-08 16:31:26.134  INFO main polkadot_service: 🚀 Using the execute-worker binary at: "/home/parity/bin/polkadot-execute-worker"
```
