### PR TITLE
separate binaries feature was refactored

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -14,21 +14,18 @@ node_data_root_path: ""
 ### Binary
 # You have to specify it in your playbook or inventory!
 node_binary: ""
+# Set it if Polkadot uses separate binaries: https://github.com/paritytech/polkadot/pull/7337
+node_prepare_worker_binary: ""
+node_execute_worker_binary: ""
+
 node_binary_download_private_token: "{{ gitlab_private_token | default(omit) }}"
 # ID of the GPG public key that is used for signing the polkadot binaries
 node_binary_release_key_id: 9D4B2B6EB8F97156D19669A9FF0812D491B96798
 # GPG signature URL. When left empty, binary verification will not be executed
 node_binary_signature: ""
-
-# Set it to true if Polkadot uses separate binaries: https://github.com/paritytech/polkadot/pull/7337
-node_separate_binary: false
-# List of binaries to download if node_separate_binary is True.
-# The first element is the main binary, and the rest are auxiliary binaries.
-node_separate_binary_list:
-  - polkadot
-  - polkadot-prepare-worker
-  - polkadot-execute-worker
-
+# Set it if Polkadot uses separate binaries: https://github.com/paritytech/polkadot/pull/7337
+node_prepare_worker_binary_signature: ""
+node_execute_worker_binary_signature: ""
 
 ### Node preferences
 # You can redefine any variables from playbooks directly

--- a/roles/node/tasks/100-tests.yml
+++ b/roles/node/tasks/100-tests.yml
@@ -5,13 +5,6 @@
     msg: "The 'node_binary' variable can't be empty!"
   when: node_binary == ''
 
-- name: Test | Check if separate binary
-  ansible.builtin.fail:
-    msg: "If 'node_separate_binary' is True, 'node_binary' and 'node_binary_signature' should end with '/'"
-  when:
-    - node_separate_binary
-    - not node_binary.endswith('/')
-
 - name: Test | Check if node_binary_signature is a URL
   ansible.builtin.fail:
     msg: "The 'node_binary_signature' variable must be a URL!"

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -1,63 +1,67 @@
 ---
 
+- name: Binary | Set variables
+  ansible.builtin.set_fact:
+    _node_binaries: "{{ [{'url': node_binary, 'signature_url': node_binary_signature, 'dst': 'polkadot'}] }}"
+    _node_temp_binary_path: "{{ _node_temp_dir.path }}/bin"
+
 - name: Binary | Create bin directory
   ansible.builtin.file:
-    path: "{{ _node_binary_file | dirname }}"
+    path: "{{ _node_binary_path }}"
     state: directory
     mode: "0755"
     owner: "{{ node_user }}"
     group: "{{ node_user }}"
 
-- name: Binary | Setup _node_temp_binary variable
+- name: Binary | Create temp bin directory
+  ansible.builtin.file:
+    path: "{{ _node_temp_binary_path }}"
+    state: directory
+    mode: "0755"
+    owner: "{{ node_user }}"
+    group: "{{ node_user }}"
+  check_mode: false
+  changed_when: false
+
+- name: Binary | Add prepare_worker to the '_node_binaries' variable
   ansible.builtin.set_fact:
-    _node_temp_binary_file: "{{ _node_temp_dir.path }}/{{ node_app_name }}"
+    _node_binaries: "{{ _node_binaries + [{'url': node_prepare_worker_binary,
+                                           'signature_url': node_prepare_worker_binary_signature,
+                                           'dst': 'polkadot-prepare-worker'}] }}"
+  when: node_prepare_worker_binary != ''
 
-- name: Binary | Download main binary
+- name: Binary | Add execute_worker to the '_node_binaries' variable
+  ansible.builtin.set_fact:
+    _node_binaries: "{{ _node_binaries + [{'url': node_execute_worker_binary,
+                                           'signature_url': node_execute_worker_binary_signature,
+                                           'dst': 'polkadot-execute-worker'}] }}"
+  when: node_execute_worker_binary != ''
+
+- name: Binary | Download binaries to temp bin directory
   ansible.builtin.get_url:
-    url: "{{ node_binary }}{{ node_separate_binary_list[0] if node_separate_binary else ''}}"
-    dest: "{{ _node_temp_binary_file }}"
+    url: "{{ item.url }}"
+    dest: "{{ _node_temp_binary_path }}/{{ item.dst }}"
     mode: 0755
     owner: "root"
     group: "root"
     timeout: 30
     headers:
       PRIVATE-TOKEN: "{{ node_binary_download_private_token }}"
+  loop: "{{ _node_binaries }}"
   check_mode: false
   changed_when: false
-
-- name: Binary | Download auxiliary binaries
-  ansible.builtin.get_url:
-    url: "{{ node_binary }}{{ item }}"
-    dest: "{{ _node_temp_dir.path }}"
-    mode: 0755
-    owner: "root"
-    group: "root"
-    timeout: 30
-    headers:
-      PRIVATE-TOKEN: "{{ node_binary_download_private_token }}"
-  check_mode: false
-  changed_when: false
-  when: node_separate_binary
-  loop: "{{ node_separate_binary_list[1:] }}"
 
 - name: Binary | GPG signature verification
   block:
 
-    - name: Binary | Download GPG signature for main binary
+    - name: Binary | Download GPG signatures for binaries
       ansible.builtin.get_url:
-        url: "{{ node_binary_signature }}{{ node_separate_binary_list[0] + '.asc' if node_separate_binary else ''}}"
-        dest: "{{ _node_temp_dir.path }}/{{ node_app_name }}.asc"
+        url: "{{ item.signature_url }}"
+        dest: "{{ _node_temp_binary_path }}/{{ item.dst }}.asc"
       check_mode: false
       changed_when: false
-
-    - name: Binary | Download GPG signature for auxiliary binaries
-      ansible.builtin.get_url:
-        url: "{{ node_binary_signature }}{{ item }}.asc"
-        dest: "{{ _node_temp_dir.path }}/{{ item }}.asc"
-      check_mode: false
-      changed_when: false
-      when: node_separate_binary
-      loop: "{{ node_separate_binary_list[1:] }}"
+      loop: "{{ _node_binaries }}"
+      when: item.signature_url != ''
 
     - name: Binary | Import release GPG public key
       ansible.builtin.command: |
@@ -67,39 +71,31 @@
       failed_when: _node_keyout.rc != 0
       check_mode: false
 
-    - name: Binary | Verify GPG signature for main binary
+    - name: Binary | Verify GPG signatures for binaries
       ansible.builtin.command: |
-        {{ _node_binary_gpg_binary }} --verify {{ _node_temp_dir.path }}/{{ node_app_name }}.asc
+        {{ _node_binary_gpg_binary }} --verify {{ _node_temp_binary_path }}/{{ item.dst }}.asc
       register: _node_verifyout
       check_mode: false
       changed_when: false
+      loop: "{{ _node_binaries }}"
+      when: item.signature_url != ''
       failed_when: _node_verifyout.rc != 0
 
-    - name: Binary | Verify GPG signature for auxiliary binaries
-      ansible.builtin.command: |
-        {{ _node_binary_gpg_binary }} --verify {{ _node_temp_dir.path }}/{{ item }}.asc
-      register: _node_verifyout
-      check_mode: false
-      changed_when: false
-      failed_when: _node_verifyout.rc != 0
-      when: node_separate_binary
-      loop: "{{ node_separate_binary_list[1:] }}"
-
-  when: node_binary_signature != ''
+  when: node_binary_signature != '' or node_prepare_worker_binary_signature != '' or node_execute_worker_binary_signature != ''
 
 - name: Binary | Check new version
-  ansible.builtin.command: "{{ _node_temp_binary_file }} --version"
+  ansible.builtin.command: "{{ _node_temp_binary_path }}/polkadot --version"
   register: _node_new_version
   check_mode: false
   changed_when: false
 
 - name: Binary | Check current binary file exists
   ansible.builtin.stat:
-    path: "{{ _node_binary_file }}"
+    path: "{{ _node_binary_path }}/polkadot"
   register: _node_binary_file_stat
 
 - name: Binary | Check current version
-  ansible.builtin.command: "{{ _node_binary_file }} --version"
+  ansible.builtin.command: "{{ _node_binary_path }}/polkadot --version"
   register: _node_current_version
   when: _node_binary_file_stat.stat.exists
   check_mode: false
@@ -124,20 +120,23 @@
 
 - name: Binary | Check current binary path exists
   ansible.builtin.stat:
-    path: "{{ _node_binary_file | dirname }}"
+    path: "{{ _node_binary_path }}"
   register: _node_binary_path_stat
 
 - name: Binary | Migration between versions
   block:
+
     - name: Binary | Check new version
-      ansible.builtin.command: "{{ _node_temp_binary_file }} --help"
+      ansible.builtin.command: "{{ _node_temp_binary_path }}/polkadot --help"
       register: _node_new_help
       check_mode: false
       changed_when: false
+
     - name: Binary | Setup supported flags
       ansible.builtin.set_fact:
         _node_legacy_rpc_flags_supported: "{{ '--ws-port' in _node_new_help.stdout }}"
         _node_separate_binary_supported: "{{ '--workers-path' in _node_new_help.stdout }}"
+
     - name: Binary | Check new rpc flags
       ansible.builtin.fail:
         msg: "ERROR: RPC flag --ws-port {{ 'IS' if _node_legacy_rpc_flags_supported else 'NOT' }} supported. 'node_legacy_rpc_flags' should be set to {{ _node_legacy_rpc_flags_supported }}"
@@ -150,38 +149,22 @@
       ansible.builtin.fail:
         msg: >
           ERROR: node flag --workers-path {{ 'IS' if _node_separate_binary_supported else 'NOT' }} supported. 
-          'node_separate_binary' should be set to {{ _node_separate_binary_supported }}, 
-          you may also need to update the 'node_binary' and 'node_separate_binary_list' variables.
-      when:
-        # XOR (skip fail if both true or both false)
-        - node_separate_binary or _node_separate_binary_supported
-        - not (node_separate_binary and _node_separate_binary_supported)
+          'node_prepare_worker_binary' and 'node_execute_worker_binary' variables should be set
+      when: _node_separate_binary_supported and (node_prepare_worker_binary == '' or node_execute_worker_binary == '')
 
 # We don't need checking of hashes. The copy module does it itself.
 # If you have the same binary file you will see a green check in the check mode.
-- name: Binary | Copy new main binary
+- name: Binary | Copy new binaries
   ansible.builtin.copy:
-    src: "{{ _node_temp_binary_file }}"
-    dest: "{{ _node_binary_file }}"
+    src: "{{ _node_temp_binary_path }}/{{ item.dst }}"
+    dest: "{{ _node_binary_path }}/{{ item.dst }}"
     remote_src: yes
     mode: 0755
     owner: "{{ node_user }}"
     group: "{{ node_user }}"
+  loop: "{{ _node_binaries }}"
   notify: restart service {{ node_handler_id }}
   ignore_errors: "{{ not _node_binary_path_stat.stat.exists }}"
-
-- name: Binary | Copy new auxiliary binaries
-  ansible.builtin.copy:
-    src: "{{ _node_temp_dir.path }}/{{ item }}"
-    dest: "{{ _node_binary_path }}/{{ item }}"
-    remote_src: yes
-    mode: 0755
-    owner: "{{ node_user }}"
-    group: "{{ node_user }}"
-  notify: restart service {{ node_handler_id }}
-  ignore_errors: "{{ not _node_binary_path_stat.stat.exists }}"
-  when: node_separate_binary
-  loop: "{{ node_separate_binary_list[1:] }}"
 
 - name: Binary | Block
   block:

--- a/roles/node/tasks/400-binary.yml
+++ b/roles/node/tasks/400-binary.yml
@@ -2,7 +2,7 @@
 
 - name: Binary | Set variables
   ansible.builtin.set_fact:
-    _node_binaries: "{{ [{'url': node_binary, 'signature_url': node_binary_signature, 'dst': 'polkadot'}] }}"
+    _node_binaries: "{{ [{'url': node_binary, 'signature_url': node_binary_signature, 'dst': _node_main_binary_file_name}] }}"
     _node_temp_binary_path: "{{ _node_temp_dir.path }}/bin"
 
 - name: Binary | Create bin directory
@@ -84,18 +84,18 @@
   when: node_binary_signature != '' or node_prepare_worker_binary_signature != '' or node_execute_worker_binary_signature != ''
 
 - name: Binary | Check new version
-  ansible.builtin.command: "{{ _node_temp_binary_path }}/polkadot --version"
+  ansible.builtin.command: "{{ _node_temp_binary_path }}/{{ _node_main_binary_file_name }} --version"
   register: _node_new_version
   check_mode: false
   changed_when: false
 
 - name: Binary | Check current binary file exists
   ansible.builtin.stat:
-    path: "{{ _node_binary_path }}/polkadot"
+    path: "{{ _node_binary_path }}/{{ _node_main_binary_file_name }}"
   register: _node_binary_file_stat
 
 - name: Binary | Check current version
-  ansible.builtin.command: "{{ _node_binary_path }}/polkadot --version"
+  ansible.builtin.command: "{{ _node_binary_path }}/{{ _node_main_binary_file_name }} --version"
   register: _node_current_version
   when: _node_binary_file_stat.stat.exists
   check_mode: false
@@ -127,7 +127,7 @@
   block:
 
     - name: Binary | Check new version
-      ansible.builtin.command: "{{ _node_temp_binary_path }}/polkadot --help"
+      ansible.builtin.command: "{{ _node_temp_binary_path }}/{{ _node_main_binary_file_name }} --help"
       register: _node_new_help
       check_mode: false
       changed_when: false
@@ -150,7 +150,10 @@
         msg: >
           ERROR: node flag --workers-path {{ 'IS' if _node_separate_binary_supported else 'NOT' }} supported. 
           'node_prepare_worker_binary' and 'node_execute_worker_binary' variables should be set
-      when: _node_separate_binary_supported and (node_prepare_worker_binary == '' or node_execute_worker_binary == '')
+      when:
+        - _node_separate_binary_supported
+        - node_role == 'validator'
+        - node_prepare_worker_binary == '' or node_execute_worker_binary == ''
 
 # We don't need checking of hashes. The copy module does it itself.
 # If you have the same binary file you will see a green check in the check mode.

--- a/roles/node/templates/node.service.j2
+++ b/roles/node/templates/node.service.j2
@@ -9,7 +9,7 @@ User={{ node_user }}
 Group={{ node_user }}
 MemoryHigh={{ node_memory_high }}
 MemoryMax={{ node_memory_max }}
-ExecStart={{ _node_binary_file }} \
+ExecStart={{ _node_binary_path }}/polkadot \
     $COMMON \
 {% if node_parachain_role != '' and node_parachain_relay_chain_rpc_urls != [] %}
     $PC_NAME $PC_ROLE_SPECIFIC $PC_KEY $PC_CHAIN $PC_REMOTE_RC_URLS $PC_ADDR $PC_CONNECTIONS $PC_DB $PC_TELEMETRY $PC_PRUNING $PC_LOGS $PC_METRICS $PC_WS $PC_RPC $PC_WASM_RUNTIME $PC_CUSTOM_OPTIONS

--- a/roles/node/templates/node.service.j2
+++ b/roles/node/templates/node.service.j2
@@ -9,7 +9,7 @@ User={{ node_user }}
 Group={{ node_user }}
 MemoryHigh={{ node_memory_high }}
 MemoryMax={{ node_memory_max }}
-ExecStart={{ _node_binary_path }}/polkadot \
+ExecStart={{ _node_binary_path }}/{{ _node_main_binary_file_name }} \
     $COMMON \
 {% if node_parachain_role != '' and node_parachain_relay_chain_rpc_urls != [] %}
     $PC_NAME $PC_ROLE_SPECIFIC $PC_KEY $PC_CHAIN $PC_REMOTE_RC_URLS $PC_ADDR $PC_CONNECTIONS $PC_DB $PC_TELEMETRY $PC_PRUNING $PC_LOGS $PC_METRICS $PC_WS $PC_RPC $PC_WASM_RUNTIME $PC_CUSTOM_OPTIONS

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -22,6 +22,7 @@ _node_memory_profiler_log_path: "{% if node_memory_profiler_log_path != '' -%}
   {{ _node_user_home_path }}/logs
   {%- endif %}"
 _node_binary_path: "{{ _node_user_home_path }}/bin/{{ node_app_name }}"
+_node_main_binary_file_name: node
 _node_memory_profiler_binary_file: "{{ _node_binary_path }}/libbytehound.so"
 _node_wasm_runtime_base_path: "{{ _node_user_home_path }}/wasm_runtime/{{ node_app_name }}"
 _node_unit_file: "/etc/systemd/system/{{ node_app_name }}.service"

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -21,8 +21,7 @@ _node_memory_profiler_log_path: "{% if node_memory_profiler_log_path != '' -%}
   {%- else -%}
   {{ _node_user_home_path }}/logs
   {%- endif %}"
-_node_binary_path: "{{ _node_user_home_path }}/bin"
-_node_binary_file: "{{ _node_binary_path }}/{{ node_app_name }}"
+_node_binary_path: "{{ _node_user_home_path }}/bin/{{ node_app_name }}"
 _node_memory_profiler_binary_file: "{{ _node_binary_path }}/libbytehound.so"
 _node_wasm_runtime_base_path: "{{ _node_user_home_path }}/wasm_runtime/{{ node_app_name }}"
 _node_unit_file: "/etc/systemd/system/{{ node_app_name }}.service"


### PR DESCRIPTION
The current implementation of separate binaries has some disadvantages:
 - previously added separate binary options have hidden logic. For example, they affect behavior of existing variables. `node_binary` variable has to contain a root HTTP path or link to a file depending of other variables
- we can't use different roots for the binary HTTP links
- we can't use arbitrary file names in binary HTTP links
- we can't deploy more than one node on one instances because worker binary files will overwrite each other

These changes make the separate binary configurate flatter (without lists) and clear. I don't think that we will have tens of separate worker binaries in the future.
