### PR TITLE
Change some default values to improve usability

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.8.3
+version: 1.9.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/key_inject/defaults/main.yml
+++ b/roles/key_inject/defaults/main.yml
@@ -2,7 +2,7 @@
 subkey_path: https://releases.parity.io/substrate/x86_64-debian%3Astretch/v3.0.0/subkey/subkey
 
 # Parachain key injection variables
-key_inject_parachain_rpc_port: 9955
+key_inject_parachain_rpc_port: 9954
 key_inject_parachain_scheme: sr25519
 # key_inject_parachain_aura_private_key=
 

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -102,7 +102,7 @@ node_db_cache: ""
 # amount of blocks to save state in the pruning mode
 # if you need the state pruning mode the recommended (default) value is 256
 # 0 - the state pruning mode is disabled, keep the state of all blocks ('--state-pruning archive')
-node_pruning: 0
+node_pruning: 256
 # You can specify any custom options as a list
 node_custom_options: []
 #  - "--wasm-execution Compiled"
@@ -204,7 +204,7 @@ node_parachain_out_peers: "25"
 # amount of blocks to save state in the pruning mode
 # if you need the state pruning mode the recommended (default) value is 256
 # 0 - the state pruning mode is disabled, keep the state of all blocks ('--state-pruning archive')
-node_parachain_pruning: 0
+node_parachain_pruning: 256
 # You can specify any custom options as a list
 node_parachain_custom_options: []
 #  - "--wasm-execution Compiled"

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -79,7 +79,7 @@ node_p2p_private_key: ""
 # Substrate changed the default rpc flags: https://github.com/paritytech/substrate/pull/13384
 # Port `9933` was replaced by combined port `9944`
 # If your node is still using the old binary with old RPC flags, please set this to true
-node_legacy_rpc_flags: true
+node_legacy_rpc_flags: false
 ## p2p
 node_p2p_bind_addr: "0.0.0.0"
 node_p2p_port: "30333"


### PR DESCRIPTION
While doing an ansible demo for the upcoming tutorial: https://github.com/paritytech/openzeppelin-rococo-parachain-ansible-quickstart , I noticed a few usability issues in our ansible role defaults.

* Make pruning=256 the default instead of archive
* Parachain Key inject port: 9954
* node_legacy_rpc_flags: false