### PR TITLE
 fix http response in the exporter for the node-backup role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.0
+version: 1.10.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node_backup/files/exporter.py
+++ b/roles/node_backup/files/exporter.py
@@ -121,11 +121,6 @@ class HttpProcessor(BaseHTTPRequestHandler):
         message = f"{self.address_string()} {format % args}"
         logging.info(message)
 
-    def _set_headers(self):
-        self.send_response(200)
-        self.send_header('Content-type', 'application/json; charset=utf-8')
-        self.end_headers()
-
 
     def do_POST(self):
         if self.headers.get('Content-Type') != 'application/json':
@@ -140,8 +135,8 @@ class HttpProcessor(BaseHTTPRequestHandler):
 
             set_metrics(json.loads(data))
             self.send_response(200)
-
-            self._set_headers()
+            self.send_header('Content-type', 'application/json; charset=utf-8')
+            self.end_headers()
             self.wfile.write(json.dumps({"status": "OK"}).encode("utf8"))
         except json.decoder.JSONDecodeError as e:
             tb_output = io.StringIO()


### PR DESCRIPTION
Changes:
 *  fixed http response in the exporter for the node-backup role. It sends two responses it is wrong http behavior and affects some clients