### PR TITLE
run GitHub workflows on all branches

### DIFF
--- a/.github/workflows/branch-main.yml
+++ b/.github/workflows/branch-main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        role-names: [node, ws_health_exporter]
+        role-names: [node, ws_health_exporter, nginx, node_backup ]
         molecule-drivers: [docker]
         # We test the latest version and minimum supported version
         ansible-versions: [8.0.0, 9.0.1]

--- a/.github/workflows/pr-nginx-exporter.yml
+++ b/.github/workflows/pr-nginx-exporter.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - roles/nginx_exporter/**
       - .github/**
+  push:
+    paths:
+      - roles/nginx_exporter/**
+      - .github/**
+    branches:
+      - '!main'
+      - '**'
 
 jobs:
   run-molecule-tests:

--- a/.github/workflows/pr-nginx.yml
+++ b/.github/workflows/pr-nginx.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - roles/nginx/**
       - .github/**
+  push:
+    paths:
+      - roles/nginx/**
+      - .github/**
+    branches:
+      - '!main'
+      - '**'
 
 jobs:
   run-molecule-tests:

--- a/.github/workflows/pr-node-backup.yml
+++ b/.github/workflows/pr-node-backup.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - roles/node_backup/**
       - .github/**
+  push:
+    paths:
+      - roles/node_backup/**
+      - .github/**
+    branches:
+      - '!main'
+      - '**'
 
 jobs:
   run-molecule-tests:

--- a/.github/workflows/pr-node.yml
+++ b/.github/workflows/pr-node.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - roles/node/**
       - .github/**
+  push:
+    paths:
+      - roles/node/**
+      - .github/**
+    branches:
+      - '!main'
+      - '**'
 
 jobs:
   run-molecule-tests:

--- a/.github/workflows/pr-secure-apt.yml
+++ b/.github/workflows/pr-secure-apt.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - roles/secure_apt/**
       - .github/**
+  push:
+    paths:
+      - roles/secure_apt/**
+      - .github/**
+    branches:
+      - '!main'
+      - '**'
 
 jobs:
   run-molecule-tests:

--- a/.github/workflows/pr-state-exporter.yml
+++ b/.github/workflows/pr-state-exporter.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - roles/state_exporter/**
       - .github/**
+  push:
+    paths:
+      - roles/state_exporter/**
+      - .github/**
+    branches:
+      - '!main'
+      - '**'
 
 jobs:
   run-molecule-tests:

--- a/.github/workflows/pr-ws-health-exporter.yml
+++ b/.github/workflows/pr-ws-health-exporter.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - roles/ws_health_exporter/**
       - .github/**
+  push:
+    paths:
+      - roles/ws_health_exporter/**
+      - .github/**
+    branches:
+      - '!main'
+      - '**'
 
 jobs:
   run-molecule-tests:


### PR DESCRIPTION
Changes:
* run GitHub workflows on all branches excluding main. the main branch is covered by another workflow. It allows to test changes in forks before PR creating
* some missed roles were added for testing in the main branch