### PR TITLE
add block rate feature to the ws_health_exporter role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.2
+version: 1.10.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/ws_health_exporter/defaults/main.yml
+++ b/roles/ws_health_exporter/defaults/main.yml
@@ -12,8 +12,10 @@ ws_health_exporter_port: 8001
 ws_health_exporter_log_level: INFO
 ws_health_exporter_ws_check_interval: 10
 ws_health_exporter_ws_timeout: 60
-ws_health_exporter_node_max_unsynchronized_block_drift: 0
-ws_health_exporter_node_min_peers: 10
+ws_health_exporter_node_max_unsynchronized_block_drift: 0 # blocks, 0 - disabled
+ws_health_exporter_node_min_peers: 10 # peers
+ws_health_exporter_min_block_rate: 0.0 # blocks/second, 0.0 - disabled
+ws_health_exporter_block_rate_measurement_period: 600 # seconds
 
 ws_health_exporter_ws_urls:
   - ws://127.0.0.1:9944

--- a/roles/ws_health_exporter/templates/.service.j2
+++ b/roles/ws_health_exporter/templates/.service.j2
@@ -11,6 +11,8 @@ Environment="WSHE_WS_CHECK_INTERVAL={{ ws_health_exporter_ws_check_interval }}"
 Environment="WSHE_WS_TIMEOUT={{ ws_health_exporter_ws_timeout }}"
 Environment="WSHE_NODE_MAX_UNSYNCHRONIZED_BLOCK_DRIFT={{ ws_health_exporter_node_max_unsynchronized_block_drift }}"
 Environment="WSHE_NODE_MIN_PEERS={{ ws_health_exporter_node_min_peers }}"
+Environment="WSHE_MIN_BLOCK_RATE={{ ws_health_exporter_min_block_rate }}"
+Environment="WSHE_BLOCK_RATE_MEASUREMENT_PERIOD={{ ws_health_exporter_block_rate_measurement_period }}"
 
 ExecStart={{ _ws_health_exporter_venv }}/bin/python3 {{ _ws_health_exporter_file }}
 


### PR DESCRIPTION
Changes:
* added block rate feature to the `ws_health_exporte`r role. The feature already exists in Python code, it just needed to be added to the role. It is disabled by default.