### PR TITLE
bump version to 1.10.5

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.4
+version: 1.10.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
Changes:
* bump version to 1.10.5. The version was not changed in [PR80](https://github.com/paritytech/ansible-polkadot/pull/80/files)