### PR TITLE
fix name

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.6
+version: 1.10.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.5
+version: 1.10.6
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -7,7 +7,7 @@ COMMON="\
 {%- endif %}"
 
 {% if ( node_parachain_relay_chain_rpc_urls | length ) == 0 %}
-RC_NAME="{% if node_parachain_has_name_fix  %}--name {{ node_public_name }}{% endif %}"
+RC_NAME="{% if node_parachain_has_name_fix  %}--name '{{ node_public_name }}'{% endif %}"
 
 RC_KEY="
 {%- if node_p2p_private_key != '' %}


### PR DESCRIPTION
Some names can break the Ansible role. Add `'` around them to prevent issues.