### PR TITLE
docs: add correct example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ collections:
 If you want to install collections in the project space, you have to run:
 ```commandline
 mkdir collections
-ansible-polkadot collection install -f -r requirements.yml -p ./collections
+ansible-galaxy collection install -f -r requirements.yml -p ./collections
 ```
 
 If you want to install collections in the global space (`~/.ansible/collections`),
 you have to run:
 ```commandline
-ansible-polkadot collection install -f -r requirements.yml
+ansible-galaxy collection install -f -r requirements.yml
 ```
 
 ## Roles


### PR DESCRIPTION
Add correct commands to the examples.
Fix the issue with the examples created by the previous bulk edit.