### PR TITLE
add debug logs variable

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -224,9 +224,6 @@ node_parachain_telemetry_url: wss://telemetry.polkadot.io/submit/ 1
 node_parachain_log_trace_enable: false
 node_parachain_log_trace_config:
   babe=trace,imonline=trace,slots=trace,sync=trace,consensus=trace,client=trace,forks=trace,txpool=debug,afg=trace,sub-authority-discovery=debug,sc_offchain=trace,runtime=trace,staking=trace,runtime::election-provider=trace
-node_log_debug_enable: false
-node_log_debug_config:
-  parachain=debug,babe=debug,imonline=debug,slots=debug,sync=debug,consensus=debug,client=debug,forks=debug,txpool=debug,afg=debug,sub-authority-discovery=debug,sc_offchain=debug,runtime=debug,staking=debug,runtime::election-provider=debug
 
 #####################################################################################
 # Advanced options

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -130,8 +130,11 @@ node_telemetry_enable: true
 # If you set an empty value, it will use the default telemetry server
 node_telemetry_url: wss:/telemetry.polkadot.io/submit/ 1
 node_log_trace_enable: false
-node_log_trace_config: 
+node_log_trace_config:
   babe=trace,imonline=trace,slots=trace,sync=trace,consensus=trace,client=trace,forks=trace,txpool=debug,afg=trace,sub-authority-discovery=debug,sc_offchain=trace,runtime=trace,staking=trace,runtime::election-provider=trace
+node_log_debug_enable: false
+node_log_debug_config:
+  parachain=debug,babe=debug,imonline=debug,slots=debug,sync=debug,consensus=debug,client=debug,forks=debug,txpool=debug,afg=debug,sub-authority-discovery=debug,sc_offchain=debug,runtime=debug,staking=debug,runtime::election-provider=debug
 
 #####################################################################################
 # Parachain
@@ -219,9 +222,11 @@ node_parachain_telemetry_enable: true
 # If you set an empty value, it will use the default telemetry server
 node_parachain_telemetry_url: wss://telemetry.polkadot.io/submit/ 1
 node_parachain_log_trace_enable: false
-node_parachain_log_trace_config: 
+node_parachain_log_trace_config:
   babe=trace,imonline=trace,slots=trace,sync=trace,consensus=trace,client=trace,forks=trace,txpool=debug,afg=trace,sub-authority-discovery=debug,sc_offchain=trace,runtime=trace,staking=trace,runtime::election-provider=trace
-
+node_log_debug_enable: false
+node_log_debug_config:
+  parachain=debug,babe=debug,imonline=debug,slots=debug,sync=debug,consensus=debug,client=debug,forks=debug,txpool=debug,afg=debug,sub-authority-discovery=debug,sc_offchain=debug,runtime=debug,staking=debug,runtime::election-provider=debug
 
 #####################################################################################
 # Advanced options

--- a/roles/node/templates/env.j2
+++ b/roles/node/templates/env.j2
@@ -72,6 +72,8 @@ RC_PRUNING="
 RC_LOGS="
 {%- if node_log_trace_enable %}
 -l{{ node_log_trace_config }}
+{%- elif node_log_debug_enable %}
+-l{{ node_log_debug_config }}
 {%- endif %}"
 
 RC_METRICS="\


### PR DESCRIPTION
We need to add support for debug logs, as we need to track issues as they occur on certain nodes. This PR adds support for adding debug logs (apart from the trace support already present). 

_Note: If trace logs are enabled, they will take precedence over debug logs, as it is the first check that is done on the presence of variables. However, this should be frowned upon, as only one of the options should be enabled._
