### PR TITLE
add the missing documentation

### DIFF
--- a/plugins/filter/subkey.py
+++ b/plugins/filter/subkey.py
@@ -6,6 +6,67 @@ from ansible.module_utils._text import to_text
 import subprocess
 import json
 
+DOCUMENTATION = '''
+name: subkey_inspect
+author: Parity Technologies
+version_added: "1.10.8"
+short_description: Inspects crypto keys using the Subkey utility
+description:
+    - Filter that runs the Subkey inspect command to analyze cryptographic keys
+    - Supports various networks and schemes
+    - Can output public key information
+    - Returns JSON formatted data about the key
+options:
+    uri:
+        description: The URI or key to inspect
+        type: str
+        required: true
+    network:
+        description: The network to use for the inspection
+        type: str
+        required: false
+        default: ''
+    scheme:
+        description: The cryptographic scheme to use
+        type: str
+        required: false
+        default: ''
+    public:
+        description: Whether to only show public key information
+        type: bool
+        required: false
+        default: false
+'''
+
+EXAMPLES = '''
+# Basic key inspection
+- debug:
+    msg: "{{ 'key_uri' | subkey_inspect }}"
+
+# Inspect with specific network
+- debug:
+    msg: "{{ 'key_uri' | subkey_inspect(network='kusama') }}"
+
+# Inspect with specific scheme and show only public info
+- debug:
+    msg: "{{ 'key_uri' | subkey_inspect(scheme='sr25519', public=true) }}"
+'''
+
+RETURN = '''
+ss58:
+    description: The SS58 address of the key
+    type: str
+    sample: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+public_key:
+    description: The public key in hex format
+    type: str
+    sample: "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+account_id:
+    description: The account ID
+    type: str
+    sample: "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+'''
+
 
 def subkey_inspect(uri, network='', scheme='', public=False):
     """Run subkey inspect command and return output."""
@@ -55,5 +116,3 @@ class FilterModule(object):
         return {
             'subkey_inspect': subkey_inspect
         }
-
-


### PR DESCRIPTION
This PR fixes the problem with the missing documentation for the `subkey_inspect` filter (ref. issue https://github.com/paritytech/ansible-polkadot/issues/91).  