### PR TITLE
[node] Clean up all stale temp directories on post-tasks

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.10
+version: 1.10.11
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/tasks/1000-post-tasks.yml
+++ b/roles/node/tasks/1000-post-tasks.yml
@@ -1,8 +1,20 @@
 ---
-- name: Post tasks | Remove temporary directory
-  ansible.builtin.file:
-    path: "{{ _node_temp_dir.path }}"
-    state: absent
+- name: Post tasks | Find temporary directories
+  ansible.builtin.find:
+    paths: /tmp
+    patterns: "ansible.*{{ _node_temp_dir_suffix }}"
+    file_type: directory
+  register: _node_temp_dirs
   check_mode: false
   changed_when: false
-  when: _node_temp_dir.path is defined
+
+- name: Post tasks | Remove temporary directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ _node_temp_dirs.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  check_mode: false
+  changed_when: false
+  when: _node_temp_dirs.files | length > 0

--- a/roles/node/tasks/200-prepare.yml
+++ b/roles/node/tasks/200-prepare.yml
@@ -35,7 +35,7 @@
 - name: Prepare | Create temporary directory
   ansible.builtin.tempfile:
     state: directory
-    suffix: polkadot_temp_dir
+    suffix: "{{ _node_temp_dir_suffix }}"
   register: _node_temp_dir
   check_mode: false
   changed_when: false

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -18,6 +18,7 @@ _node_binary_path: "{{ _node_user_home_path }}/bin/{{ node_app_name }}"
 _node_main_binary_file_name: node
 _node_memory_profiler_binary_file: "{{ _node_binary_path }}/libbytehound.so"
 _node_wasm_runtime_base_path: "{{ _node_user_home_path }}/wasm_runtime/{{ node_app_name }}"
+_node_temp_dir_suffix: polkadot_temp_dir
 _node_unit_file: /etc/systemd/system/{{ node_app_name }}.service
 
 _node_chain_backup_http_rclone_deb: https://downloads.rclone.org/v1.63.1/rclone-v1.63.1-linux-amd64.deb


### PR DESCRIPTION
- Previously only the current run's temp directory was cleaned up. If a previous run failed or was interrupted, its `/tmp/ansible.*polkadot_temp_dir` directories were left behind, accumulating and filling up disk space.
- Now uses `find` + `file` loop to remove all matching stale temp directories, with the suffix extracted into a variable for maintainability.

Ref: https://github.com/paritytech/devops/issues/4931