### PR TITLE
[ws_health_exporter] Fix idempotence test failure

### DIFF
--- a/roles/ws_health_exporter/tasks/main.yml
+++ b/roles/ws_health_exporter/tasks/main.yml
@@ -68,4 +68,3 @@
         name: "{{ _ws_health_exporter_name }}"
         state: started
         enabled: true
-        daemon_reload: true


### PR DESCRIPTION
Remove redundant `daemon_reload: true` from the "start exporter service" task. This was causing the molecule idempotence test to fail because `daemon_reload` always reports `changed`, even when the service is already running.

The `daemon_reload` is already handled by the `restart ws-health-exporter` handler (in `handlers/main.yml`), which is triggered when the binary or systemd unit file changes. On subsequent runs where nothing changes, no handler fires and there's nothing to reload.

This also unblocks the Galaxy publish for 1.10.11.