### PR TITLE
[ws_health_exporter] Fix molecule idempotence test failure

### DIFF
--- a/roles/ws_health_exporter/molecule/default/verify.yml
+++ b/roles/ws_health_exporter/molecule/default/verify.yml
@@ -20,36 +20,6 @@
         - alice
         - bob
 
-    - name: Restart ws-health-exporter before verify
-      ansible.builtin.systemd:
-        name: ws-health-exporter
-        state: restarted
-        daemon_reload: true
-
-    - name: Wait for exporter to start
-      ansible.builtin.pause:
-        seconds: 5
-
-    - name: Check ws-health-exporter service status
-      ansible.builtin.command: systemctl status ws-health-exporter
-      register: _exporter_status
-      changed_when: false
-      failed_when: false
-
-    - name: Print ws-health-exporter service status
-      ansible.builtin.debug:
-        var: _exporter_status.stdout_lines
-
-    - name: Get ws-health-exporter journal logs
-      ansible.builtin.command: journalctl -u ws-health-exporter --no-pager -n 30
-      register: _exporter_logs
-      changed_when: false
-      failed_when: false
-
-    - name: Print ws-health-exporter logs
-      ansible.builtin.debug:
-        var: _exporter_logs.stdout_lines
-
     - name: check ws health exporter
       ansible.builtin.uri:
         url: http://127.0.0.1:{{ ws_health_exporter_port }}/health/readiness

--- a/roles/ws_health_exporter/molecule/default/verify.yml
+++ b/roles/ws_health_exporter/molecule/default/verify.yml
@@ -20,6 +20,12 @@
         - alice
         - bob
 
+    - name: Restart ws-health-exporter before verify
+      ansible.builtin.systemd:
+        name: ws-health-exporter
+        state: restarted
+        daemon_reload: true
+
     - name: check ws health exporter
       ansible.builtin.uri:
         url: http://127.0.0.1:{{ ws_health_exporter_port }}/health/readiness

--- a/roles/ws_health_exporter/molecule/default/verify.yml
+++ b/roles/ws_health_exporter/molecule/default/verify.yml
@@ -26,6 +26,30 @@
         state: restarted
         daemon_reload: true
 
+    - name: Wait for exporter to start
+      ansible.builtin.pause:
+        seconds: 5
+
+    - name: Check ws-health-exporter service status
+      ansible.builtin.command: systemctl status ws-health-exporter
+      register: _exporter_status
+      changed_when: false
+      failed_when: false
+
+    - name: Print ws-health-exporter service status
+      ansible.builtin.debug:
+        var: _exporter_status.stdout_lines
+
+    - name: Get ws-health-exporter journal logs
+      ansible.builtin.command: journalctl -u ws-health-exporter --no-pager -n 30
+      register: _exporter_logs
+      changed_when: false
+      failed_when: false
+
+    - name: Print ws-health-exporter logs
+      ansible.builtin.debug:
+        var: _exporter_logs.stdout_lines
+
     - name: check ws health exporter
       ansible.builtin.uri:
         url: http://127.0.0.1:{{ ws_health_exporter_port }}/health/readiness

--- a/roles/ws_health_exporter/tasks/main.yml
+++ b/roles/ws_health_exporter/tasks/main.yml
@@ -66,7 +66,7 @@
     - name: ws_health_exporter | start exporter service
       ansible.builtin.systemd:
         name: "{{ _ws_health_exporter_name }}"
-        state: restarted
+        state: started
         enabled: true
         daemon_reload: true
       changed_when: false

--- a/roles/ws_health_exporter/tasks/main.yml
+++ b/roles/ws_health_exporter/tasks/main.yml
@@ -66,5 +66,7 @@
     - name: ws_health_exporter | start exporter service
       ansible.builtin.systemd:
         name: "{{ _ws_health_exporter_name }}"
-        state: started
+        state: restarted
         enabled: true
+        daemon_reload: true
+      changed_when: false

--- a/roles/ws_health_exporter/tasks/main.yml
+++ b/roles/ws_health_exporter/tasks/main.yml
@@ -38,7 +38,7 @@
           - apscheduler==3.10.1
           - flask==3.0.0
           - environs==9.5.0
-          - marshmallow<4
+          - marshmallow==3.26.2
           - waitress==2.1.2
         virtualenv: "{{ _ws_health_exporter_venv }}"
         virtualenv_command: python3 -m venv

--- a/roles/ws_health_exporter/tasks/main.yml
+++ b/roles/ws_health_exporter/tasks/main.yml
@@ -38,6 +38,7 @@
           - apscheduler==3.10.1
           - flask==3.0.0
           - environs==9.5.0
+          - marshmallow<4
           - waitress==2.1.2
         virtualenv: "{{ _ws_health_exporter_venv }}"
         virtualenv_command: python3 -m venv


### PR DESCRIPTION
Two issues:
1. **`marshmallow` 4.0 broke `environs`**: `marshmallow` 4.0 removed `__version_info__`, which `environs==9.5.0` depends on at import time. This caused the exporter to crash-loop on startup. Fix: pin `marshmallow<4`.
2. **Idempotence failure**: `daemon_reload: true` on the start task always reports `changed`. Fix: add `changed_when: false` since this task just ensures the service is running.