### PR TITLE
[nginx] Install logrotate to enable log rotation

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: paritytech
 name: chain
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.11
+version: 1.10.12
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -26,6 +26,7 @@
         packeges:
           - nginx
           - certbot
+          - logrotate
 
     - name: nginx | create directories
       ansible.builtin.file:


### PR DESCRIPTION
Bootnodes don't have logrotate installed, causing nginx logs to grow unbounded (2.5GB+ access.log on polkadot-bootnode-1). The logrotate config file exists from the nginx package but logrotate itself isn't installed.

Ref: https://github.com/paritytech/devops/issues/4931